### PR TITLE
Support custom emulator hosts and ports

### DIFF
--- a/packages/dart_firebase_admin/lib/src/app/firebase_admin.dart
+++ b/packages/dart_firebase_admin/lib/src/app/firebase_admin.dart
@@ -1,13 +1,32 @@
 part of '../app.dart';
 
 class FirebaseAdminApp {
-  FirebaseAdminApp.initializeApp(this.projectId, this.credential);
+  FirebaseAdminApp.initializeApp(
+    this.projectId,
+    this.credential, {
+    this.emulatorAuthHost = '127.0.0.1',
+    this.emulatorAuthPort = 9099,
+    this.emulatorFirestoreHost = '127.0.0.1',
+    this.emulatorFirestorePort = 8080,
+  });
 
   /// The ID of the Google Cloud project associated with the app.
   final String projectId;
 
   /// The [Credential] used to authenticate the Admin SDK.
   final Credential credential;
+
+  /// The hostname of the Firebase Auth emulator.
+  final String emulatorAuthHost;
+
+  /// The port of the Firebase Auth emulator.
+  final int emulatorAuthPort;
+
+  /// The hostname of the Firestore emulator.
+  final String emulatorFirestoreHost;
+
+  /// The port of the Firestore emulator.
+  final int emulatorFirestorePort;
 
   bool get isUsingEmulator => _isUsingEmulator;
   var _isUsingEmulator = false;
@@ -20,8 +39,14 @@ class FirebaseAdminApp {
   /// Use the Firebase Emulator Suite to run the app locally.
   void useEmulator() {
     _isUsingEmulator = true;
-    authApiHost = Uri.http('127.0.0.1:9099', 'identitytoolkit.googleapis.com/');
-    firestoreApiHost = Uri.http('127.0.0.1:8080', '/');
+    authApiHost = Uri.http(
+      '$emulatorAuthHost:$emulatorAuthPort',
+      'identitytoolkit.googleapis.com/',
+    );
+    firestoreApiHost = Uri.http(
+      '$emulatorFirestoreHost:$emulatorFirestorePort',
+      '/',
+    );
   }
 
   /// Stops the app and releases any resources associated with it.

--- a/packages/dart_firebase_admin/test/firebase_admin_app_test.dart
+++ b/packages/dart_firebase_admin/test/firebase_admin_app_test.dart
@@ -10,14 +10,17 @@ void main() {
       );
 
       expect(app, isA<FirebaseAdminApp>());
-      expect(app.authApiHost, Uri.https('identitytoolkit.googleapis.com', '/'));
+      expect(
+        app.authApiHost,
+        Uri.https('identitytoolkit.googleapis.com', '/'),
+      );
       expect(
         app.firestoreApiHost,
-        Uri.https('identitytoolkit.googleapis.com', '/'),
+        Uri.https('firestore.googleapis.com', '/'),
       );
     });
 
-    test('useEmulator() sets the apiHost to the emulator', () {
+    test('useEmulator() sets the default emulator hosts to the emulator', () {
       final app = FirebaseAdminApp.initializeApp(
         'dart-firebase-admin',
         Credential.fromApplicationDefaultCredentials(),
@@ -30,9 +33,34 @@ void main() {
         Uri.http('127.0.0.1:9099', 'identitytoolkit.googleapis.com/'),
       );
       expect(
-        app.authApiHost,
-        Uri.http('127.0.0.1:8080', 'identitytoolkit.googleapis.com/'),
+        app.firestoreApiHost,
+        Uri.http('127.0.0.1:8080', '/'),
       );
     });
+
+    test(
+      'useEmulator() leverages custom hosts and ports',
+      () {
+        final app = FirebaseAdminApp.initializeApp(
+          'dart-firebase-admin',
+          Credential.fromApplicationDefaultCredentials(),
+          emulatorAuthHost: 'localhost',
+          emulatorAuthPort: 1099,
+          emulatorFirestoreHost: 'localhost',
+          emulatorFirestorePort: 1080,
+        );
+
+        app.useEmulator();
+
+        expect(
+          app.authApiHost,
+          Uri.http('localhost:1099', 'identitytoolkit.googleapis.com/'),
+        );
+        expect(
+          app.firestoreApiHost,
+          Uri.http('localhost:1080', '/'),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
I have multiple projects with different emulator ports so I thought it would be beneficial to be able to configure this. 