### PR TITLE
Update reference.dart

### DIFF
--- a/packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart
+++ b/packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart
@@ -1502,7 +1502,7 @@ class Query<T> {
   /// ```dart
   /// final query = firestore.collection('col').where('foo', WhereFilter.equal, 42);
   ///
-  /// query.orderBy('foo', 'desc').get().then((querySnapshot) {
+  /// query.orderBy('foo', descending: true).get().then((querySnapshot) {
   ///   querySnapshot.forEach((documentSnapshot) {
   ///     print('Found document at ${documentSnapshot.ref.path}');
   ///   });
@@ -1546,7 +1546,7 @@ class Query<T> {
   /// ```dart
   /// final query = firestore.collection('col').where('foo', WhereFilter.equal, 42);
   ///
-  /// query.orderBy('foo', 'desc').get().then((querySnapshot) {
+  /// query.orderBy('foo', descending: true).get().then((querySnapshot) {
   ///   querySnapshot.forEach((documentSnapshot) {
   ///     print('Found document at ${documentSnapshot.ref.path}');
   ///   });


### PR DESCRIPTION
This pull request includes changes to the `Query` class in the `packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart` file. The changes modify the way the `orderBy` method is used in the examples provided in the comments. Instead of using a string to indicate the sort order, a named boolean parameter `descending` is now used.

Main changes:

* [`packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart`](diffhunk://#diff-83cc41fd2118cb8871636d4dd19b797664332c1665cff22e43d3fde1d77a451cL1505-R1505): In the `Query` class, the `orderBy` method in the examples has been changed from using a string parameter to indicate the sort order to using a named boolean parameter `descending`. This change has been applied in two places in the comments. [[1]](diffhunk://#diff-83cc41fd2118cb8871636d4dd19b797664332c1665cff22e43d3fde1d77a451cL1505-R1505) [[2]](diffhunk://#diff-83cc41fd2118cb8871636d4dd19b797664332c1665cff22e43d3fde1d77a451cL1549-R1549)