### PR TITLE
mark Auth.verifyIdToken as not supported in README.md

### DIFF
--- a/packages/dart_firebase_admin/README.md
+++ b/packages/dart_firebase_admin/README.md
@@ -261,7 +261,7 @@ final link = await auth.generatePasswordResetLink(
 | auth.deleteProviderConfig             | ✅  |
 | auth.createCustomToken                | ✅  |
 | auth.setCustomUserClaims              | ✅  |
-| auth.verifyIdToken                    | ✅  |
+| auth.verifyIdToken                    | ❌  |
 | auth.revokeRefreshTokens              | ✅  |
 | auth.createSessionCookie              | ✅  |
 | auth.verifySessionCookie              | ✅  |


### PR DESCRIPTION
Auth.verifyIdToken throws UnimplementedError. This PR updates the README to reflect that this method is not supported.

related issue: https://github.com/invertase/dart_firebase_admin/issues/20