### PR TITLE
chore: Bump intl 0.19.0 to 0.20.0

### DIFF
--- a/packages/dart_firebase_admin/CHANGELOG.md
+++ b/packages/dart_firebase_admin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased minor
+
+- Bump intl to `0.20.0`
+
 ## 0.4.0 - 2024-09-11
 
 - Added `firestore.listCollections()` and `doc.listCollections()`

--- a/packages/dart_firebase_admin/pubspec.yaml
+++ b/packages/dart_firebase_admin/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   googleapis_auth: ^1.3.0
   http: ^1.0.0
-  intl: ^0.19.0
+  intl: ^0.20.0
   meta: ^1.9.1
 
 dev_dependencies:


### PR DESCRIPTION
## Related Issues

fixes 
```
ERROR: ERROR: ERROR: Because pos_core_dart depends on dart_firebase_admin ^0.4.0 which depends on intl ^0.19.0, intl ^0.19.0 is required.
So, because pos_core_dart depends on intl ^0.20.1, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on intl: dart pub add intl:^0.19.0
```

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
