### PR TITLE
Interruption Level for APS to deliver time-sensitive notifications for IOS

### DIFF
--- a/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
@@ -452,6 +452,7 @@ class Aps {
     this.mutableContent,
     this.category,
     this.threadId,
+    this.interruptionLevel,
   });
 
   /// Alert to be included in the message. This may be a string or an object of
@@ -478,6 +479,10 @@ class Aps {
   /// An app-specific identifier for grouping notifications.
   final String? threadId;
 
+  /// Specifies the interruption level of the notification.
+  /// Usually critical or time-sensitive.
+  final String? interruptionLevel;
+
   Map<String, Object?> _toProto() {
     return {
       if (alert != null) 'alert': alert?._toProto(),
@@ -487,6 +492,7 @@ class Aps {
       if (mutableContent != null) 'mutable-content': mutableContent,
       if (category != null) 'category': category,
       if (threadId != null) 'thread-id': threadId,
+      if (interruptionLevel != null) 'interruption-level': interruptionLevel,
     }._cleanProto();
   }
 }

--- a/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
@@ -453,6 +453,7 @@ class Aps {
     this.category,
     this.threadId,
     this.interruptionLevel,
+    this.soundRaw,
   });
 
   /// Alert to be included in the message. This may be a string or an object of
@@ -483,11 +484,15 @@ class Aps {
   /// Usually critical or time-sensitive.
   final String? interruptionLevel;
 
+  /// The sound name directly inserted as "sound": "sound_name" in the payload.
+  final String? soundRaw;
+
   Map<String, Object?> _toProto() {
     return {
       if (alert != null) 'alert': alert?._toProto(),
       if (badge != null) 'badge': badge,
-      if (sound != null) 'sound': sound?._toProto(),
+      if (sound != null || soundRaw != null)
+        'sound': sound?._toProto() ?? soundRaw,
       if (contentAvailable != null) 'content-available': contentAvailable,
       if (mutableContent != null) 'mutable-content': mutableContent,
       if (category != null) 'category': category,


### PR DESCRIPTION
fixes #80

Simply adds time-sensitive as a property for APS and allows it to play instead of getting rejected on firebases end.

You can now deliver time sensitive notifications with sound on IOS 

* Added String? interruptionLevel and String? soundRaw to the Aps model
* If sound is defined, that is serialized, otherwise soundRaw is, if neither are defined, the sound field is not included in the map.

```dart
MulticastMessage(
  tokens: ...,
  data: ...,
  notification: Notification(title: title, body: body),
  apns: ApnsConfig(
    headers: {"apns-priority": "5"}, // Firebase requires 5, anything higher is rejected
    payload: ApnsPayload(
      aps: Aps(
        soundRaw: "default", // Makes it play a sound on ios. Using "CriticalSound" object rejects the notification on firebase.
        interruptionLevel: "time-sensitive", // Actually makes the notification time sensitive
      ),
    ),
  ),
)
```

This is the correct way to deliver Aps payload with time-sensitive and with actual sound, the CriticalSound object is not up to aps spec and it just gets rejected by firebase, notifications wont even deliver using that.