### PR TITLE
Fix #83: Removed unnecessary check

### DIFF
--- a/packages/dart_firebase_admin/lib/src/google_cloud_firestore/path.dart
+++ b/packages/dart_firebase_admin/lib/src/google_cloud_firestore/path.dart
@@ -231,8 +231,6 @@ sealed class FieldMask {
   factory FieldMask.fieldPath(FieldPath fieldPath) = _FieldPathFieldMask;
 }
 
-final _fieldPathRegex = RegExp(r'^[^*~/[\]]+$');
-
 class _StringFieldMask implements FieldMask {
   _StringFieldMask(this.path) {
     if (path.contains('..')) {
@@ -248,14 +246,6 @@ class _StringFieldMask implements FieldMask {
         path,
         'path',
         'must not start or end with "."',
-      );
-    }
-
-    if (!_fieldPathRegex.hasMatch(path)) {
-      throw ArgumentError.value(
-        path,
-        'path',
-        "Paths can't be empty and must not contain '*~/[]'.",
       );
     }
   }


### PR DESCRIPTION
## Related Issues

Fixes #83

---

Changes:
1. Removed the unnecessary check in the `_StringFieldMask` constructor that thrown `ArgumentError` when field paths contained any of `*~/[]` characters. All of these characters are allowed in Firestore field names it seems.