### PR TITLE
expose the payload on a decoded token to allow access to custom claims

### DIFF
--- a/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
@@ -315,6 +315,7 @@ class DecodedIdToken {
     required this.picture,
     required this.sub,
     required this.uid,
+    required this.payload,
   });
 
   @internal
@@ -334,6 +335,7 @@ class DecodedIdToken {
       picture: map['picture'] as String?,
       sub: map['sub']! as String,
       uid: map['sub']! as String,
+      payload: map,
     );
   }
 
@@ -408,11 +410,9 @@ class DecodedIdToken {
   /// convenience, and is set as the value of the [`sub`](#sub) property.
   String uid;
 
-  /**
-   * Other arbitrary claims included in the ID token.
-   */
-  // TODO allow any key
-  // [key: string]: any;
+  /// Allow access to other, custom claims by exposing the original payload
+  Map<String,Object?> payload;
+
 }
 
 /// User facing token information related to the Firebase ID token.


### PR DESCRIPTION
If custom claims have been set via a custom token creation they are currently not accessible via the decoded token.
This PR exposes the original payload to access custom claims.
https://firebase.google.com/docs/auth/admin/create-custom-tokens#database-rules_1

It also finishes the todo in the code.

Let me know what you think.