### PR TITLE
refactor!: rework app init flow and credential management

### DIFF
--- a/packages/dart_firebase_admin/example/lib/main.dart
+++ b/packages/dart_firebase_admin/example/lib/main.dart
@@ -3,12 +3,7 @@ import 'package:dart_firebase_admin/firestore.dart';
 import 'package:dart_firebase_admin/messaging.dart';
 
 Future<void> main() async {
-  final admin = FirebaseAdminApp.initializeApp(
-    'dart-firebase-admin',
-    Credential.fromApplicationDefaultCredentials(),
-  );
-
-  // // admin.useEmulator();
+  final admin = FirebaseAdmin.initializeApp();
 
   final messaging = Messaging(admin);
 

--- a/packages/dart_firebase_admin/lib/src/app.dart
+++ b/packages/dart_firebase_admin/lib/src/app.dart
@@ -6,10 +6,10 @@ import 'dart:io';
 
 import 'package:googleapis/identitytoolkit/v3.dart' as auth3;
 import 'package:googleapis_auth/auth_io.dart' as auth;
-import 'package:googleapis_auth/googleapis_auth.dart';
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 
+part 'firebase_admin.dart';
 part 'app/credential.dart';
 part 'app/exception.dart';
 part 'app/firebase_admin.dart';

--- a/packages/dart_firebase_admin/lib/src/app/credential.dart
+++ b/packages/dart_firebase_admin/lib/src/app/credential.dart
@@ -43,51 +43,107 @@ class _EmulatorClient extends BaseClient {
   }
 }
 
-/// Authentication information for Firebase Admin SDK.
-class Credential {
-  Credential._(
-    this.serviceAccountCredentials, {
-    this.serviceAccountId,
-  }) : assert(
-          serviceAccountId == null || serviceAccountCredentials == null,
-          'Cannot specify both serviceAccountId and serviceAccountCredentials',
-        );
+/// Base class for Firebase Admin SDK credentials.
+///
+/// Use [ServiceAccountCredential] for service account credentials,
+/// or [ApplicationDefaultCredential] for Application Default Credentials.
+sealed class Credential {
+  /// Factory to create a credential using Application Default Credentials.
+  factory Credential.fromApplicationDefaultCredentials({
+    String? serviceAccountId,
+  }) {
+    return ApplicationDefaultCredential.fromEnvironment(
+      serviceAccountId: serviceAccountId,
+    );
+  }
 
-  /// Log in to firebase from a service account file.
+  /// Factory to create a credential from a service account file.
   factory Credential.fromServiceAccount(File serviceAccountFile) {
-    final content = serviceAccountFile.readAsStringSync();
+    return ServiceAccountCredential.fromFile(serviceAccountFile);
+  }
 
+  /// Private constructor for sealed class.
+  Credential._();
+
+  /// Returns the underlying [auth.ServiceAccountCredentials] if this is a
+  /// [ServiceAccountCredential], null otherwise.
+  @internal
+  auth.ServiceAccountCredentials? get serviceAccountCredentials;
+
+  /// Returns the service account ID (email) if available.
+  @internal
+  String? get serviceAccountId;
+}
+
+/// Extended service account credentials that includes projectId.
+///
+/// This wraps [auth.ServiceAccountCredentials] and adds the [projectId] field
+/// which is required for Firebase Admin SDK operations.
+@internal
+final class ServiceAccountCredential extends Credential {
+  /// Creates a [ServiceAccountCredential] from a JSON object.
+  factory ServiceAccountCredential.fromJson(Map<String, Object?> json) {
+    // Extract and validate projectId - required for service accounts
+    final projectId = json['project_id'] as String?;
+    if (projectId == null || projectId.isEmpty) {
+      throw const FormatException(
+        'Service account JSON must contain a "project_id" property',
+      );
+    }
+
+    // Use parent's fromJson to create the base credentials
+    final credentials = auth.ServiceAccountCredentials.fromJson(json);
+
+    return ServiceAccountCredential._(credentials, projectId);
+  }
+
+  /// Creates a [ServiceAccountCredential] from a service account JSON file.
+  factory ServiceAccountCredential.fromFile(File serviceAccountFile) {
+    final content = serviceAccountFile.readAsStringSync();
     final json = jsonDecode(content);
     if (json is! Map<String, Object?>) {
       throw const FormatException('Invalid service account file');
     }
 
-    final serviceAccountCredentials =
-        auth.ServiceAccountCredentials.fromJson(json);
-
-    return Credential._(serviceAccountCredentials);
+    return ServiceAccountCredential.fromJson(json);
   }
+  ServiceAccountCredential._(
+    this._credentials,
+    this.projectId,
+  ) : super._();
 
-  /// Log in to firebase from a service account file parameters.
-  factory Credential.fromServiceAccountParams({
-    required String clientId,
-    required String privateKey,
-    required String email,
-  }) {
-    final serviceAccountCredentials = auth.ServiceAccountCredentials(
-      email,
-      ClientId(clientId),
-      privateKey,
-    );
+  final auth.ServiceAccountCredentials _credentials;
 
-    return Credential._(serviceAccountCredentials);
-  }
+  /// The Google Cloud project ID associated with this service account.
+  final String projectId;
 
-  /// Log in to firebase using the environment variable.
-  factory Credential.fromApplicationDefaultCredentials({
+  /// The service account email (client_email).
+  String get clientEmail => _credentials.email;
+
+  /// The private key.
+  String get privateKey => _credentials.privateKey;
+
+  @override
+  auth.ServiceAccountCredentials get serviceAccountCredentials => _credentials;
+
+  @override
+  String? get serviceAccountId => _credentials.email;
+}
+
+/// Application Default Credentials for Firebase Admin SDK.
+///
+/// Uses Google Application Default Credentials (ADC) which can be:
+/// - A service account file specified via GOOGLE_APPLICATION_CREDENTIALS
+/// - Compute Engine default service account
+/// - Other ADC sources
+@internal
+final class ApplicationDefaultCredential extends Credential {
+  /// Factory to create from environment (GOOGLE_APPLICATION_CREDENTIALS).
+  factory ApplicationDefaultCredential.fromEnvironment({
     String? serviceAccountId,
   }) {
-    ServiceAccountCredentials? creds;
+    auth.ServiceAccountCredentials? creds;
+    String? projectId;
 
     final env =
         Zone.current[envSymbol] as Map<String, String>? ?? Platform.environment;
@@ -97,20 +153,108 @@ class Credential {
         final text = File(maybeConfig).readAsStringSync();
         final decodedValue = jsonDecode(text);
         if (decodedValue is Map) {
-          creds = ServiceAccountCredentials.fromJson(decodedValue);
+          creds = auth.ServiceAccountCredentials.fromJson(decodedValue);
+          projectId = decodedValue['project_id'] as String?;
         }
-      } on FormatException catch (_) {}
+      } on FormatException catch (_) {
+        // Ignore parsing errors, will fall back to metadata service
+      }
     }
 
-    return Credential._(
-      creds,
+    return ApplicationDefaultCredential(
       serviceAccountId: serviceAccountId,
+      serviceAccountCredentials: creds,
+      projectId: projectId,
     );
   }
+  ApplicationDefaultCredential({
+    String? serviceAccountId,
+    auth.ServiceAccountCredentials? serviceAccountCredentials,
+    String? projectId,
+  })  : _serviceAccountId = serviceAccountId,
+        _serviceAccountCredentials = serviceAccountCredentials,
+        _projectId = projectId,
+        super._();
 
-  @internal
-  final String? serviceAccountId;
+  final String? _serviceAccountId;
+  final auth.ServiceAccountCredentials? _serviceAccountCredentials;
+  final String? _projectId;
 
-  @internal
-  final auth.ServiceAccountCredentials? serviceAccountCredentials;
+  @override
+  auth.ServiceAccountCredentials? get serviceAccountCredentials =>
+      _serviceAccountCredentials;
+
+  @override
+  String? get serviceAccountId =>
+      _serviceAccountId ?? _serviceAccountCredentials?.email;
+
+  /// The project ID if available from the service account file.
+  /// For Compute Engine, this needs to be fetched asynchronously via metadata service.
+  String? get projectId => _projectId;
+
+  /// Fetches the project ID from the metadata service (for Compute Engine).
+  /// Returns null if not available.
+  Future<String?> getProjectId() async {
+    if (_projectId != null) {
+      return _projectId;
+    }
+
+    // Try to get from metadata service
+    try {
+      final response = await get(
+        Uri.parse(
+          'http://metadata/computeMetadata/v1/project/project-id',
+        ),
+        headers: {
+          'Metadata-Flavor': 'Google',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        return response.body;
+      }
+    } catch (_) {
+      // Not on Compute Engine or metadata service unavailable
+    }
+
+    return null;
+  }
+
+  /// Fetches the service account email from the metadata service (for Compute Engine).
+  /// Returns null if not available.
+  Future<String?> getServiceAccountEmail() async {
+    if (_serviceAccountId != null) {
+      return _serviceAccountId;
+    }
+
+    if (_serviceAccountCredentials != null) {
+      return _serviceAccountCredentials.email;
+    }
+
+    // Try to get from metadata service
+    try {
+      final response = await get(
+        Uri.parse(
+          'http://metadata/computeMetadata/v1/instance/service-accounts/default/email',
+        ),
+        headers: {
+          'Metadata-Flavor': 'Google',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        return response.body;
+      }
+    } catch (_) {
+      // Not on Compute Engine or metadata service unavailable
+    }
+
+    return null;
+  }
+}
+
+/// Helper function to get Application Default Credential.
+@internal
+ApplicationDefaultCredential getApplicationDefault() {
+  return ApplicationDefaultCredential.fromEnvironment();
 }

--- a/packages/dart_firebase_admin/lib/src/app/exception.dart
+++ b/packages/dart_firebase_admin/lib/src/app/exception.dart
@@ -83,3 +83,24 @@ abstract class FirebaseAdminException implements Exception {
     return '$runtimeType($code, $message)';
   }
 }
+
+/// App client error codes.
+class AppErrorCode {
+  static const appDeleted = 'app-deleted';
+  static const duplicateApp = 'duplicate-app';
+  static const invalidArgument = 'invalid-argument';
+  static const internalError = 'internal-error';
+  static const invalidAppName = 'invalid-app-name';
+  static const invalidAppOptions = 'invalid-app-options';
+  static const invalidCredential = 'invalid-credential';
+  static const networkError = 'network-error';
+  static const networkTimeout = 'network-timeout';
+  static const noApp = 'no-app';
+  static const unableToParseResponse = 'unable-to-parse-response';
+}
+
+/// Exception thrown for Firebase App-related errors.
+class FirebaseAppException extends FirebaseAdminException {
+  FirebaseAppException(String code, [String? message])
+      : super('app', code, message);
+}

--- a/packages/dart_firebase_admin/lib/src/app/firebase_admin.dart
+++ b/packages/dart_firebase_admin/lib/src/app/firebase_admin.dart
@@ -1,46 +1,126 @@
 part of '../app.dart';
 
 class FirebaseAdminApp {
-  FirebaseAdminApp.initializeApp(
-    this.projectId,
-    this.credential, {
+  FirebaseAdminApp._({
+    required this.name,
     Client? client,
-  }) : _clientOverride = client;
+    String? projectId,
+    Credential? credential,
+    String? serviceAccountId,
+    String? storageBucket,
+  })  : _clientOverride = client,
+        options = _createAppOptions(
+          credential:
+              credential ?? Credential.fromApplicationDefaultCredentials(),
+          projectId: projectId,
+          serviceAccountId: serviceAccountId,
+          storageBucket: storageBucket,
+        );
 
-  /// The ID of the Google Cloud project associated with the app.
-  final String projectId;
+  final String name;
 
-  /// The [Credential] used to authenticate the Admin SDK.
-  final Credential credential;
+  final AppOptions options;
 
-  bool get isUsingEmulator => _isUsingEmulator;
-  var _isUsingEmulator = false;
+  /// The ID of the Google Cloud project associated with the App.
+  String? get projectId => options.projectId;
+
+  Uri? _authApiHost;
+  Uri? _firestoreApiHost;
+  Uri? _tasksEmulatorHost;
+
+  /// Creates AppOptions with automatic credential and serviceAccountId resolution.
+  static AppOptions _createAppOptions({
+    required Credential credential,
+    String? projectId,
+    String? serviceAccountId,
+    String? storageBucket,
+  }) {
+    // Priority 1: Explicitly provided projectId
+    var resolvedProjectId = projectId;
+
+    // Priority 2: From service account credential (if we have one)
+    if (resolvedProjectId == null) {
+      if (credential case final ServiceAccountCredential sa) {
+        resolvedProjectId = sa.projectId;
+      }
+    }
+
+    // Priority 3: From environment variables (GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT)
+    if (resolvedProjectId == null) {
+      final env = Zone.current[envSymbol] as Map<String, String>? ??
+          Platform.environment;
+      resolvedProjectId = env['GOOGLE_CLOUD_PROJECT'] ?? env['GCLOUD_PROJECT'];
+    }
+
+    // Throw if projectId still cannot be determined
+    if (resolvedProjectId == null || resolvedProjectId.isEmpty) {
+      throw FirebaseAppException(
+        AppErrorCode.invalidCredential,
+        'Failed to determine project ID. Initialize the SDK with service account '
+        'credentials or set project ID as an app option. Alternatively, set the '
+        'GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT environment variable.',
+      );
+    }
+
+    // Extract serviceAccountId from credential if not provided
+    var resolvedServiceAccountId = serviceAccountId;
+    if (resolvedServiceAccountId == null) {
+      if (credential case final ServiceAccountCredential sa) {
+        resolvedServiceAccountId = sa.clientEmail;
+      } else {
+        resolvedServiceAccountId = credential.serviceAccountId;
+      }
+    }
+
+    return AppOptions._(
+      credential: credential,
+      projectId: resolvedProjectId,
+      serviceAccountId: resolvedServiceAccountId,
+      storageBucket: storageBucket,
+    );
+  }
 
   @internal
-  Uri authApiHost = Uri.https('identitytoolkit.googleapis.com', '/');
-  @internal
-  Uri firestoreApiHost = Uri.https('firestore.googleapis.com', '/');
-  @internal
-  String tasksEmulatorHost = 'https://cloudfunctions.googleapis.com/';
+  bool get isUsingEmulator {
+    final env =
+        Zone.current[envSymbol] as Map<String, String>? ?? Platform.environment;
+    return env.containsKey('FIREBASE_AUTH_EMULATOR_HOST') ||
+        env.containsKey('FIRESTORE_EMULATOR_HOST') ||
+        env.containsKey('CLOUD_TASKS_EMULATOR_HOST');
+  }
 
-  /// Use the Firebase Emulator Suite to run the app locally.
-  void useEmulator() {
-    _isUsingEmulator = true;
+  Uri? _getEnvironmentVariableHost(String name) {
     final env =
         Zone.current[envSymbol] as Map<String, String>? ?? Platform.environment;
 
-    authApiHost = Uri.http(
-      env['FIREBASE_AUTH_EMULATOR_HOST'] ?? '127.0.0.1:9099',
-      'identitytoolkit.googleapis.com/',
-    );
-    firestoreApiHost = Uri.http(
-      env['FIRESTORE_EMULATOR_HOST'] ?? '127.0.0.1:8080',
-      '/',
-    );
-    tasksEmulatorHost = Uri.http(
-      env['CLOUD_TASKS_EMULATOR_HOST'] ?? '127.0.0.1:5001',
-      '/',
-    ).toString();
+    final value = env[name];
+
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+
+    return Uri.http(value, '/');
+  }
+
+  @internal
+  Uri get authApiHost {
+    return _authApiHost ??=
+        _getEnvironmentVariableHost('FIREBASE_AUTH_EMULATOR_HOST') ??
+            Uri.https('identitytoolkit.googleapis.com', '/');
+  }
+
+  @internal
+  Uri get firestoreApiHost {
+    return _firestoreApiHost ??=
+        _getEnvironmentVariableHost('FIRESTORE_EMULATOR_HOST') ??
+            Uri.https('firestore.googleapis.com', '/');
+  }
+
+  @internal
+  Uri get tasksEmulatorHost {
+    return _tasksEmulatorHost ??=
+        _getEnvironmentVariableHost('CLOUD_TASKS_EMULATOR_HOST') ??
+            Uri.https('cloudfunctions.googleapis.com', '/');
   }
 
   @internal
@@ -50,6 +130,7 @@ class FirebaseAdminApp {
       auth3.IdentityToolkitApi.firebaseScope,
     ],
   );
+
   final Client? _clientOverride;
 
   Future<Client> _getClient(List<String> scopes) async {
@@ -61,7 +142,8 @@ class FirebaseAdminApp {
       return _EmulatorClient(Client());
     }
 
-    final serviceAccountCredentials = credential.serviceAccountCredentials;
+    final serviceAccountCredentials =
+        options.credential.serviceAccountCredentials;
     final client = serviceAccountCredentials == null
         ? await auth.clientViaApplicationDefaultCredentials(scopes: scopes)
         : await auth.clientViaServiceAccount(serviceAccountCredentials, scopes);
@@ -74,4 +156,43 @@ class FirebaseAdminApp {
     final client = await this.client;
     client.close();
   }
+
+  /// Deletes the Firebase app instance and removes it from the registry.
+  ///
+  /// This method makes the app unusable and frees resources of all associated
+  /// services. It also removes the app from the FirebaseAdmin app registry.
+  ///
+  /// This is called by [FirebaseAdmin.deleteApp].
+  @internal
+  Future<void> delete() async {
+    // Close and release resources
+    await close();
+
+    // Remove from registry
+    FirebaseAdmin._apps.remove(name);
+  }
+}
+
+final class AppOptions {
+  const AppOptions._({
+    required this.credential,
+    required this.projectId,
+    this.serviceAccountId,
+    this.storageBucket,
+  });
+
+  /// A [Credential] object used to authenticate the Admin SDK.
+  final Credential credential;
+  // final Object? databaseAuthVariableOverride; // TODO:
+  // final String? databaseURL; // TODO: Implement once database support
+  // final Object? httpAgent; // TODO: Do we need this? Looks like a nodejs thing.
+
+  /// The ID of the Google Cloud project associated with the App.
+  final String projectId;
+
+  /// The ID of the service account to be used for signing custom tokens. This can be found in the `client_email` field of a service account JSON file.
+  final String? serviceAccountId;
+
+  /// The name of the Google Cloud Storage bucket used for storing application data. Use only the bucket name without any prefixes or additions (do *not* prefix the name with "gs://").
+  final String? storageBucket;
 }

--- a/packages/dart_firebase_admin/lib/src/app_check/token_verifier.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/token_verifier.dart
@@ -19,7 +19,7 @@ class AppCheckTokenVerifier {
       PublicKeySignatureVerifier.withJwksUrl(Uri.parse(jwksUrl));
 
   Future<DecodedAppCheckToken> verifyToken(String token) async {
-    final decoded = await _decodeAndVerify(token, app.projectId);
+    final decoded = await _decodeAndVerify(token, app.options.projectId);
 
     return DecodedAppCheckToken.fromMap(decoded.payload);
   }

--- a/packages/dart_firebase_admin/lib/src/auth/auth_api_request.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_api_request.dart
@@ -333,7 +333,7 @@ abstract class _AbstractAuthRequestHandler {
 
       final response = await client.projects.createSessionCookie(
         request,
-        app.projectId,
+        app.options.projectId,
       );
 
       final sessionCookie = response.sessionCookie;
@@ -393,7 +393,7 @@ abstract class _AbstractAuthRequestHandler {
     return _httpClient.v1((client) async {
       final response = await client.projects.accounts_1.batchCreate(
         request,
-        app.projectId,
+        app.options.projectId,
       );
       // No error object is returned if no error encountered.
       // Rewrite response as UserImportResult and re-insert client previously detected errors.
@@ -434,7 +434,7 @@ abstract class _AbstractAuthRequestHandler {
     return _httpClient.v1((client) async {
       // TODO handle tenants
       return client.projects.accounts_1.batchGet(
-        app.projectId,
+        app.options.projectId,
         maxResults: maxResults,
         nextPageToken: pageToken,
       );
@@ -451,7 +451,7 @@ abstract class _AbstractAuthRequestHandler {
     return _httpClient.v1((client) async {
       return client.projects.accounts_1.delete(
         auth1.GoogleCloudIdentitytoolkitV1DeleteAccountRequest(localId: uid),
-        app.projectId,
+        app.options.projectId,
       );
     });
   }
@@ -477,7 +477,7 @@ abstract class _AbstractAuthRequestHandler {
           localIds: uids,
           force: force,
         ),
-        app.projectId,
+        app.options.projectId,
       );
     });
   }
@@ -506,7 +506,7 @@ abstract class _AbstractAuthRequestHandler {
           phoneNumber: properties.phoneNumber?.value,
           photoUrl: properties.photoURL?.value,
         ),
-        app.projectId,
+        app.options.projectId,
       );
 
       final localId = response.localId;

--- a/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
@@ -75,7 +75,7 @@ class FirebaseTokenVerifier {
   }) async {
     final decoded = await _decodeAndVerify(
       jwtToken,
-      projectId: app.projectId,
+      projectId: app.options.projectId,
       isEmulator: isEmulator,
     );
 

--- a/packages/dart_firebase_admin/lib/src/firebase_admin.dart
+++ b/packages/dart_firebase_admin/lib/src/firebase_admin.dart
@@ -1,0 +1,196 @@
+part of 'app.dart';
+
+/// Root Firebase Admin SDK instance that manages Firebase app instances.
+class FirebaseAdmin {
+  FirebaseAdmin._();
+
+  static final FirebaseAdmin instance = FirebaseAdmin._();
+
+  static const String _defaultAppName = '[DEFAULT]';
+
+  static final Map<String, FirebaseAdminApp> _apps = {};
+
+  /// Initializes a Firebase app instance.
+  ///
+  /// Creates a new instance if one doesn't exist, or returns an existing
+  /// app instance if one exists with the same name and options.
+  ///
+  /// Throws [FirebaseAppException] if an app with the same name already
+  /// exists with different options.
+  ///
+  /// [name] defaults to `[DEFAULT]` if not provided.
+  static FirebaseAdminApp initializeApp({
+    String? name,
+    Client? client,
+    String? projectId,
+    Credential? credential,
+    String? serviceAccountId,
+    String? storageBucket,
+  }) {
+    final appName = name ?? _defaultAppName;
+    _validateAppName(appName);
+
+    // If app already exists, check if options match
+    if (_apps.containsKey(appName)) {
+      final existingApp = _apps[appName]!;
+      if (!_optionsMatch(
+        existingApp: existingApp.options,
+        projectId: projectId,
+        serviceAccountId: serviceAccountId,
+        storageBucket: storageBucket,
+        credential: credential,
+      )) {
+        throw FirebaseAppException(
+          AppErrorCode.duplicateApp,
+          'A Firebase app named "$appName" already exists with a different configuration.',
+        );
+      }
+      return existingApp;
+    }
+
+    // Create new app
+    final app = FirebaseAdminApp._(
+      name: appName,
+      client: client,
+      projectId: projectId,
+      credential: credential,
+      serviceAccountId: serviceAccountId,
+      storageBucket: storageBucket,
+    );
+
+    _apps[appName] = app;
+    return app;
+  }
+
+  /// Returns an existing Firebase app instance.
+  ///
+  /// [name] defaults to `[DEFAULT]` if not provided.
+  ///
+  /// Throws [FirebaseAppException] if no app exists for the given name.
+  FirebaseAdminApp app([String? name]) {
+    final appName = name ?? _defaultAppName;
+    _validateAppName(appName);
+
+    if (!_apps.containsKey(appName)) {
+      final errorMessage = appName == _defaultAppName
+          ? 'The default Firebase app does not exist. '
+          : 'Firebase app named "$appName" does not exist. ';
+      throw FirebaseAppException(
+        AppErrorCode.noApp,
+        '${errorMessage}Make sure you call initializeApp() before using any of the Firebase services.',
+      );
+    }
+
+    return _apps[appName]!;
+  }
+
+  /// Returns a list of all initialized Firebase app instances.
+  static List<FirebaseAdminApp> getApps() => List.unmodifiable(_apps.values);
+
+  /// Returns an existing Firebase app instance.
+  ///
+  /// [name] defaults to `[DEFAULT]` if not provided.
+  ///
+  /// Throws [FirebaseAppException] if no app exists for the given name.
+  static FirebaseAdminApp getApp([String? name]) {
+    final appName = name ?? _defaultAppName;
+    _validateAppName(appName);
+
+    if (!_apps.containsKey(appName)) {
+      final errorMessage = appName == _defaultAppName
+          ? 'The default Firebase app does not exist. '
+          : 'Firebase app named "$appName" does not exist. ';
+      throw FirebaseAppException(
+        AppErrorCode.noApp,
+        '${errorMessage}Make sure you call initializeApp() before using any of the Firebase services.',
+      );
+    }
+
+    return _apps[appName]!;
+  }
+
+  /// Deletes a Firebase app instance and releases all associated resources.
+  ///
+  /// This method makes the app unusable and frees resources of all associated
+  /// services. When running locally, this method should be called to ensure
+  /// graceful termination of the process.
+  ///
+  /// Throws [FirebaseAppException] if the app argument is invalid or doesn't exist.
+  static Future<void> deleteApp(FirebaseAdminApp app) async {
+    // Validate app has required properties
+    try {
+      // Access name to ensure it's a valid app instance
+      final appName = app.name;
+      if (appName.isEmpty) {
+        throw FirebaseAppException(
+          AppErrorCode.invalidArgument,
+          'Invalid app argument.',
+        );
+      }
+    } catch (e) {
+      throw FirebaseAppException(
+        AppErrorCode.invalidArgument,
+        'Invalid app argument.',
+      );
+    }
+
+    // Make sure the given app already exists
+    final existingApp = getApp(app.name);
+
+    // Delegate delete operation to the App instance itself
+    await existingApp.delete();
+  }
+}
+
+/// Compares options to see if they match an existing app.
+///
+/// Note: We don't compare credentials or client as they can't be reliably
+/// compared. If a credential is provided, we throw an error (matching Node.js behavior).
+bool _optionsMatch({
+  required AppOptions existingApp,
+  String? projectId,
+  String? serviceAccountId,
+  String? storageBucket,
+  Credential? credential,
+}) {
+  // If credential is explicitly provided, we can't reliably compare it
+  // Node.js throws in this case, so we return false to trigger the throw
+  if (credential != null) {
+    return false;
+  }
+
+  // Compare projectId - must match if provided
+  if (projectId != null && projectId != existingApp.projectId) {
+    return false;
+  }
+
+  // Compare serviceAccountId - must match if provided
+  if (serviceAccountId != null &&
+      serviceAccountId != existingApp.serviceAccountId) {
+    return false;
+  }
+
+  // Compare storageBucket - must match if provided
+  if (storageBucket != null && storageBucket != existingApp.storageBucket) {
+    return false;
+  }
+
+  // All provided options match
+  return true;
+}
+
+void _validateAppName(String name) {
+  if (name.isEmpty) {
+    throw FirebaseAppException(
+      AppErrorCode.invalidAppName,
+      'App name cannot be empty.',
+    );
+  }
+  // App name must not contain ':' character
+  if (name.contains(':')) {
+    throw FirebaseAppException(
+      AppErrorCode.invalidAppName,
+      'App name cannot contain the character ":".',
+    );
+  }
+}

--- a/packages/dart_firebase_admin/lib/src/google_cloud_firestore/firestore.dart
+++ b/packages/dart_firebase_admin/lib/src/google_cloud_firestore/firestore.dart
@@ -105,7 +105,7 @@ class Firestore {
 
     return DocumentReference._(
       firestore: this,
-      path: path._toQualifiedResourcePath(app.projectId, _databaseId),
+      path: path._toQualifiedResourcePath(app.options.projectId, _databaseId),
       converter: _jsonConverter,
     );
   }
@@ -132,7 +132,7 @@ class Firestore {
 
     return CollectionReference._(
       firestore: this,
-      path: path._toQualifiedResourcePath(app.projectId, _databaseId),
+      path: path._toQualifiedResourcePath(app.options.projectId, _databaseId),
       converter: _jsonConverter,
     );
   }

--- a/packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart
+++ b/packages/dart_firebase_admin/lib/src/google_cloud_firestore/reference.dart
@@ -86,7 +86,7 @@ final class CollectionReference<T> extends Query<T> {
   /// [DocumentSnapshot] whose [DocumentSnapshot.exists] property is `false`.
   Future<List<DocumentReference<T>>> listDocuments() async {
     final parentPath = _queryOptions.parentPath._toQualifiedResourcePath(
-      firestore.app.projectId,
+      firestore.app.options.projectId,
       firestore._databaseId,
     );
 
@@ -195,7 +195,7 @@ final class DocumentReference<T> implements _Serializable {
   String get _formattedName {
     return _path
         ._toQualifiedResourcePath(
-          firestore.app.projectId,
+          firestore.app.options.projectId,
           firestore._databaseId,
         )
         ._formattedName;
@@ -1190,7 +1190,7 @@ base class Query<T> {
   String _buildProtoParentPath() {
     return _queryOptions.parentPath
         ._toQualifiedResourcePath(
-          firestore.app.projectId,
+          firestore.app.options.projectId,
           firestore._databaseId,
         )
         ._formattedName;

--- a/packages/dart_firebase_admin/lib/src/utils/credential_utils.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/credential_utils.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import '../../dart_firebase_admin.dart';
+
+/// Returns the Google Cloud project ID associated with a Firebase app, if it's explicitly
+/// specified in either the Firebase app options, credentials or the local environment.
+/// Otherwise returns null.
+///
+/// This matches the Node.js `getExplicitProjectId` function behavior.
+String? getExplicitProjectId(FirebaseAdminApp app) {
+  final options = app.options;
+  
+  // Priority 1: Explicitly provided in options
+  if (options.projectId != null && options.projectId!.isNotEmpty) {
+    return options.projectId;
+  }
+
+  final credential = app.options.credential;
+  
+  // Priority 2: From ServiceAccountCredential
+  if (credential case ServiceAccountCredential sa) {
+    return sa.projectId;
+  }
+
+  // Priority 3: From environment variables
+  final env = Platform.environment;
+  final projectId = env['GOOGLE_CLOUD_PROJECT'] ?? env['GCLOUD_PROJECT'];
+  if (projectId != null && projectId.isNotEmpty) {
+    return projectId;
+  }
+
+  return null;
+}
+
+/// Determines the Google Cloud project ID associated with a Firebase app. This method
+/// first checks if a project ID is explicitly specified in either the Firebase app options,
+/// credentials or the local environment in that order. If no explicit project ID is
+/// configured, but the SDK has been initialized with ApplicationDefaultCredential, this
+/// method attempts to discover the project ID from the local metadata service.
+///
+/// This matches the Node.js `findProjectId` function behavior.
+Future<String?> findProjectId(FirebaseAdminApp app) async {
+  final projectId = getExplicitProjectId(app);
+  if (projectId != null) {
+    return projectId;
+  }
+
+  final credential = app.options.credential;
+  if (credential case ApplicationDefaultCredential adc) {
+    return await adc.getProjectId();
+  }
+
+  return null;
+}
+
+/// Returns the service account email associated with a Firebase app, if it's explicitly
+/// specified in either the Firebase app options or credentials.
+/// Otherwise returns null.
+///
+/// This matches the Node.js `getExplicitServiceAccountEmail` function behavior.
+String? getExplicitServiceAccountEmail(FirebaseAdminApp app) {
+  final options = app.options;
+  
+  // Priority 1: Explicitly provided in options
+  if (options.serviceAccountId != null && options.serviceAccountId!.isNotEmpty) {
+    return options.serviceAccountId;
+  }
+
+  final credential = app.options.credential;
+  
+  // Priority 2: From ServiceAccountCredential
+  if (credential case ServiceAccountCredential sa) {
+    return sa.clientEmail;
+  }
+
+  return null;
+}
+
+/// Determines the service account email associated with a Firebase app. This method first
+/// checks if a service account email is explicitly specified in either the Firebase app options,
+/// credentials or the local environment in that order. If no explicit service account email is
+/// configured, but the SDK has been initialized with ApplicationDefaultCredential, this
+/// method attempts to discover the service account email from the local metadata service.
+///
+/// This matches the Node.js `findServiceAccountEmail` function behavior.
+Future<String?> findServiceAccountEmail(FirebaseAdminApp app) async {
+  final accountId = getExplicitServiceAccountEmail(app);
+  if (accountId != null) {
+    return accountId;
+  }
+
+  final credential = app.options.credential;
+  if (credential case ApplicationDefaultCredential adc) {
+    return await adc.getServiceAccountEmail();
+  }
+
+  return null;
+}
+

--- a/packages/dart_firebase_admin/lib/src/utils/crypto_signer.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/crypto_signer.dart
@@ -30,7 +30,7 @@ Future<R> _v1<R>(
 @internal
 abstract class CryptoSigner {
   static CryptoSigner fromApp(FirebaseAdminApp app) {
-    final credential = app.credential;
+    final credential = app.options.credential;
     final serviceAccountCredentials = credential.serviceAccountCredentials;
     if (serviceAccountCredentials != null) {
       return _ServiceAccountSigner(serviceAccountCredentials);
@@ -50,7 +50,7 @@ abstract class CryptoSigner {
 }
 
 class _IAMSigner implements CryptoSigner {
-  _IAMSigner(this.app) : _serviceAccountId = app.credential.serviceAccountId;
+  _IAMSigner(this.app) : _serviceAccountId = app.options.credential.serviceAccountId;
 
   @override
   String get algorithm => 'RS256';


### PR DESCRIPTION
This PR aims to align the app API more closely with Node. Changes:

- `FirebaseAdminApp` is now has a private constructor.
- `FirebaseAdmin` class exists, with static `initalizeApp` + `getApps` etc methods
- The params for `initalizeApp` are now all optional, whereas right now they are required
- The options for an app exist on `AppOptions` (should probably name this `FirebaseAppOptions`(?), inline with the node sdk. This also adds support for some missing options such as storage bucket which we'll need.
- The `projectId` (now inside of `AppOptions`) will always exist. Like node, it first checks for a user provided value, then the credential (if its a service account), then finally the environment. Which allows no options to `initalizeApp`, for use on GCP environments.
- There's also a couple of useful methods for fetching from say Compute Engine if it's running there, as per the node sdk.
- Credential has been reworked - its now a sealed class, and a credential can either be a `ServiceAccountCredential` or `ApplicationDefaultCredential`, which is used to detect the projectId.