### PR TITLE
fix(auth): use base64url encoding for JWT segments in createCustomToken

### DIFF
--- a/packages/dart_firebase_admin/lib/src/auth/token_generator.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/token_generator.dart
@@ -103,7 +103,7 @@ class _FirebaseTokenGenerator {
   String _encodeSegment(Object? segment) {
     final buffer =
         segment is Uint8List ? segment : utf8.encode(jsonEncode(segment));
-    return base64Encode(buffer).replaceFirst(RegExp(r'=+$'), '');
+    return base64Url.encode(buffer).replaceAll('=', '');
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #16

`createCustomToken` produces JWTs that Firebase Auth rejects with `invalid-custom-token` because the token segments are encoded with standard base64 instead of base64url.

- **Root cause:** `_encodeSegment` in `token_generator.dart` used `base64Encode` (standard base64, which uses `+` and `/` characters) instead of `base64Url.encode` (base64url, which uses `-` and `_` characters per [RFC 4648 Section 5](https://tools.ietf.org/html/rfc4648#section-5)).
- **Effect:** The JWT header, payload, and signature all contained non-URL-safe characters, violating the JWS Compact Serialization format required by [RFC 7515 Section 2](https://tools.ietf.org/html/rfc7515#section-2). Firebase Auth correctly rejected these tokens.
- **Fix:** Replace `base64Encode(buffer).replaceFirst(RegExp(r'=+$'), '')` with `base64Url.encode(buffer).replaceAll('=', '')`.

Note: The app_check `token_generator.dart` already handles this correctly via its `_toWebSafeBase64` helper -- this PR brings the auth token generator in line with that approach using Dart's built-in `base64Url` codec.

This is a minimal one-line change. No new dependencies are introduced.

## Related

- Closes #16 — `createCustomToken` produces tokens rejected by Firebase Auth
- Supersedes #23 (which was closed without merging) — PR #23 also fixed the RSA signing (HMAC-SHA256 to proper RSA-SHA256), which has since been addressed separately. The base64url encoding issue remained.

## Test plan

- [ ] Verify `createCustomToken` output passes [jwt.io](https://jwt.io) validation without base64url warnings
- [ ] Verify `signInWithCustomToken` succeeds on a Flutter client using the generated token
- [ ] Verify the signature segment is 342 base64url characters (256 bytes) for RS256