### PR TITLE
fix(auth): fix token signing service account email extraction

### DIFF
--- a/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
@@ -4,7 +4,7 @@ import '../app.dart';
 
 extension AppExtension on FirebaseApp {
   Future<String> get serviceAccountEmail async =>
-      options.credential?.serviceAccountCredentials?.email ??
+      options.credential?.serviceAccountId ??
       (await client).getServiceAccountEmail();
 
   /// Signs the given data using the IAM Credentials API or local credentials.
@@ -18,6 +18,7 @@ extension AppExtension on FirebaseApp {
           data,
           serviceAccountCredentials:
               options.credential?.serviceAccountCredentials,
+          serviceAccountEmail: options.credential?.serviceAccountId,
           endpoint: endpoint,
         );
 }


### PR DESCRIPTION
## Description
This PR fixes a bug in the Firebase Admin SDK where generating custom tokens or signing bytes failed if the application was initialized using Workload Identity Federation / Application Default Credentials (ADC). 

### The Issue
Previously, the SDK was attempting to extract the service account email directly from `options.credential?.serviceAccountCredentials?.email`. However, when using ADC, the `serviceAccountCredentials` property is explicitly `null`. This resulted in the IAM signing layer lacking the necessary target principal to execute the `signBlob` API correctly. 

### The Fix
* **`app_extension.dart`**: Refactored the `serviceAccountEmail` getter to rely on `options.credential?.serviceAccountId` (which works for both Standard Service Accounts and ADC).
* Passed `options.credential?.serviceAccountId` directly to the underlying `googleapis_auth` library's `client.sign` method, ensuring that token generation requests are properly attributed to the target service account.

*Note: This PR is dependent on the `googleapis_auth` library update that introduces the `serviceAccountEmail` parameter to `AuthClientSigningExtension.sign`.* https://github.com/google/googleapis.dart/pull/731
