### PR TITLE
test: Workload Identity Federation integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,9 @@ jobs:
   test:
     name: Test (Dart ${{ matrix.dart-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     strategy:
       fail-fast: false
@@ -75,7 +78,7 @@ jobs:
         working-directory: packages/dart_firebase_admin
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -89,6 +92,12 @@ jobs:
       - uses: subosito/flutter-action@v2.7.1
         with:
           channel: ${{ matrix.dart-version }}
+
+      - name: Authenticate to Google Cloud/Firebase
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.SERVICE_ACCOUNT }}'
 
       - name: Cache pub dependencies
         uses: actions/cache@v3
@@ -122,11 +131,6 @@ jobs:
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
-
-      - name: Setup gcloud credentials
-        run: |
-          mkdir -p $HOME/.config/gcloud
-          echo '${{ secrets.CREDS }}' > $HOME/.config/gcloud/application_default_credentials.json
 
       - name: Run dart_firebase_admin tests with coverage
         run: ${{ github.workspace }}/scripts/coverage.sh

--- a/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
@@ -4,7 +4,7 @@ import '../app.dart';
 
 extension AppExtension on FirebaseApp {
   Future<String> get serviceAccountEmail async =>
-      options.credential?.serviceAccountCredentials?.email ??
+      options.credential?.serviceAccountId ??
       (await client).getServiceAccountEmail();
 
   /// Signs the given data using the IAM Credentials API or local credentials.
@@ -18,6 +18,7 @@ extension AppExtension on FirebaseApp {
           data,
           serviceAccountCredentials:
               options.credential?.serviceAccountCredentials,
+          serviceAccountEmail: options.credential?.serviceAccountId,
           endpoint: endpoint,
         );
 }

--- a/packages/dart_firebase_admin/pubspec.yaml
+++ b/packages/dart_firebase_admin/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   google_cloud_firestore: ^0.1.0
   google_cloud_storage: ^0.5.1
   googleapis: ^15.0.0
-  googleapis_auth: ^2.1.0
+  googleapis_auth: ^2.2.0
   googleapis_beta: ^9.0.0
   http: ^1.0.0
   intl: ^0.20.0

--- a/packages/dart_firebase_admin/test/app/firebase_app_integration_test.dart
+++ b/packages/dart_firebase_admin/test/app/firebase_app_integration_test.dart
@@ -36,7 +36,7 @@ void main() {
           },
         );
       },
-      skip: !hasGoogleEnv
+      skip: !hasProdEnv
           ? 'Skipping client creation tests. '
                 'Set GOOGLE_APPLICATION_CREDENTIALS to run these tests.'
           : false,

--- a/packages/dart_firebase_admin/test/app/firebase_app_prod_test.dart
+++ b/packages/dart_firebase_admin/test/app/firebase_app_prod_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dart_firebase_admin/auth.dart';
 import 'package:dart_firebase_admin/src/app.dart';
 import 'package:test/test.dart';
 
@@ -26,7 +27,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv()});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GOOGLE_APPLICATION_CREDENTIALS to be set',
         timeout: const Timeout(Duration(seconds: 30)),
@@ -47,7 +48,7 @@ void main() {
             expect(app.isDeleted, isTrue);
           }, zoneValues: {envSymbol: prodEnv()});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GOOGLE_APPLICATION_CREDENTIALS to be set',
         timeout: const Timeout(Duration(seconds: 30)),
@@ -77,7 +78,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv()});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GOOGLE_APPLICATION_CREDENTIALS to be set',
         timeout: const Timeout(Duration(seconds: 30)),
@@ -102,10 +103,82 @@ void main() {
             }
           }, zoneValues: {envSymbol: null});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GOOGLE_APPLICATION_CREDENTIALS to be set',
         timeout: const Timeout(Duration(seconds: 30)),
+      );
+    });
+
+    group('Workload Identity Federation tests', () {
+      late FirebaseApp app;
+
+      setUpAll(() async {
+        // Initialize via WIF (ADC)
+        app = FirebaseApp.initializeApp(
+          options: AppOptions(
+            credential: Credential.fromApplicationDefaultCredentials(
+              serviceAccountId:
+                  'firebase-adminsdk-fbsvc@dart-firebase-admin.iam.gserviceaccount.com',
+            ),
+            projectId: 'dart-firebase-admin',
+          ),
+        );
+      });
+
+      test(
+        'should initializeApp via WIF (ADC)',
+        () {
+          expect(app, isNotNull);
+        },
+        skip: hasWifEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      );
+
+      test(
+        'should test Auth (getUsers)',
+        () async {
+          final auth = app.auth();
+          expect(auth, isNotNull);
+
+          final listUsersResult = await auth.listUsers(maxResults: 1);
+          expect(listUsersResult.users, isA<List<UserRecord>>());
+        },
+        skip: hasWifEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      );
+
+      test(
+        'should test Firestore (write + read)',
+        () async {
+          final db = app.firestore();
+          expect(db, isNotNull);
+
+          final docRef = db.collection('wif-demo').doc('test-connection');
+          const testMessage = 'Hello from GitHub Actions WIF!';
+
+          await docRef.set({
+            'timestamp': DateTime.now().toIso8601String(),
+            'message': testMessage,
+          });
+
+          final doc = await docRef.get();
+          expect(doc.exists, isTrue);
+          expect(doc.data()?['message'], equals(testMessage));
+          expect(doc.data()?['timestamp'], isNotNull);
+        },
+        skip: hasWifEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      );
+
+      test(
+        'should test signed tokens (createCustomToken)',
+        () async {
+          final auth = app.auth();
+          const uid = 'wif-demo-user-123';
+
+          final customToken = await auth.createCustomToken(uid);
+          expect(customToken, isNotNull);
+          expect(customToken, isA<String>());
+        },
+        skip: hasWifEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
     });
   });

--- a/packages/dart_firebase_admin/test/app_check/app_check_test.dart
+++ b/packages/dart_firebase_admin/test/app_check/app_check_test.dart
@@ -327,7 +327,7 @@ void main() {
 
     group('e2e', () {
       test(
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
         'should create and verify token',
         () {
           return runZoned(() async {
@@ -357,7 +357,7 @@ void main() {
       );
 
       test(
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
         'should create token with custom ttl',
         () {
           return runZoned(() async {
@@ -382,7 +382,7 @@ void main() {
       );
 
       test(
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
         'should verify token with consume option',
         () {
           return runZoned(() async {

--- a/packages/dart_firebase_admin/test/auth/auth_integration_prod_test.dart
+++ b/packages/dart_firebase_admin/test/auth/auth_integration_prod_test.dart
@@ -66,7 +66,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Requires production to verify custom claims clearing',
     );
@@ -138,7 +138,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Session cookies require GCIP (not available in emulator)',
     );
@@ -225,7 +225,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Session cookies require GCIP (not available in emulator)',
     );
@@ -293,7 +293,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Session cookies require GCIP (not available in emulator)',
     );
@@ -326,7 +326,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Session cookies require GCIP (not available in emulator)',
     );
@@ -380,7 +380,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'getUsers not fully supported in Firebase Auth Emulator',
     );
@@ -418,7 +418,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'getUsers not fully supported in Firebase Auth Emulator',
     );
@@ -468,7 +468,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Provider configs require GCIP (not available in emulator)',
     );
@@ -515,7 +515,7 @@ void main() {
           }
         }, zoneValues: {envSymbol: prodEnv});
       },
-      skip: hasGoogleEnv
+      skip: hasProdEnv
           ? false
           : 'Provider configs require GCIP (not available in emulator)',
     );

--- a/packages/dart_firebase_admin/test/auth/auth_test.dart
+++ b/packages/dart_firebase_admin/test/auth/auth_test.dart
@@ -104,7 +104,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires production mode but runs with emulator auto-detection',
       );
@@ -748,36 +748,24 @@ void main() {
     });
 
     group('createCustomToken', () {
-      test(
-        'creates a valid JWT token',
-        () async {
-          final token = await auth.createCustomToken('test-uid');
+      test('creates a valid JWT token', () async {
+        final token = await auth.createCustomToken('test-uid');
 
-          expect(token, isNotEmpty);
-          expect(token, isA<String>());
-          // Token should be in JWT format (3 parts separated by dots)
-          expect(token.split('.').length, equals(3));
-        },
-        skip: hasGoogleEnv
-            ? false
-            : 'Requires GOOGLE_APPLICATION_CREDENTIALS for service account',
-      );
+        expect(token, isNotEmpty);
+        expect(token, isA<String>());
+        // Token should be in JWT format (3 parts separated by dots)
+        expect(token.split('.').length, equals(3));
+      });
 
-      test(
-        'creates token with developer claims',
-        () async {
-          final token = await auth.createCustomToken(
-            'test-uid',
-            developerClaims: {'admin': true, 'level': 5},
-          );
+      test('creates token with developer claims', () async {
+        final token = await auth.createCustomToken(
+          'test-uid',
+          developerClaims: {'admin': true, 'level': 5},
+        );
 
-          expect(token, isNotEmpty);
-          expect(token, isA<String>());
-        },
-        skip: hasGoogleEnv
-            ? false
-            : 'Requires GOOGLE_APPLICATION_CREDENTIALS for service account',
-      );
+        expect(token, isNotEmpty);
+        expect(token, isA<String>());
+      });
 
       test('throws when uid is empty', () async {
         expect(

--- a/packages/dart_firebase_admin/test/auth/project_config_integration_prod_test.dart
+++ b/packages/dart_firebase_admin/test/auth/project_config_integration_prod_test.dart
@@ -28,7 +28,7 @@ void main() {
 
   // Save original config before running update tests
   setUpAll(() async {
-    if (!hasGoogleEnv) return;
+    if (!hasProdEnv) return;
 
     // Remove emulator env var from the zone environment
     final prodEnv = Map<String, String>.from(Platform.environment);
@@ -54,7 +54,7 @@ void main() {
 
   // Restore original config after all tests complete
   tearDownAll(() async {
-    if (!hasGoogleEnv || originalConfig == null) return;
+    if (!hasProdEnv || originalConfig == null) return;
 
     // Remove emulator env var from the zone environment
     final prodEnv = Map<String, String>.from(Platform.environment);
@@ -127,7 +127,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -189,7 +189,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -243,7 +243,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -306,7 +306,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -358,7 +358,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -407,7 +407,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires reCAPTCHA Enterprise configuration',
       );
@@ -470,7 +470,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );

--- a/packages/dart_firebase_admin/test/auth/tenant_integration_prod_test.dart
+++ b/packages/dart_firebase_admin/test/auth/tenant_integration_prod_test.dart
@@ -99,7 +99,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -163,7 +163,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -227,7 +227,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -298,7 +298,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Requires GCIP (Google Cloud Identity Platform)',
       );
@@ -354,7 +354,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv ? false : 'Requires production Firebase',
+        skip: hasProdEnv ? false : 'Requires production Firebase',
       );
 
       test(
@@ -425,7 +425,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv ? false : 'Requires production Firebase',
+        skip: hasProdEnv ? false : 'Requires production Firebase',
       );
     });
 
@@ -521,7 +521,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Session cookies require GCIP (not available in emulator)',
       );
@@ -635,7 +635,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Session cookies require GCIP (not available in emulator)',
       );
@@ -769,7 +769,7 @@ void main() {
             }
           }, zoneValues: {envSymbol: prodEnv});
         },
-        skip: hasGoogleEnv
+        skip: hasProdEnv
             ? false
             : 'Session cookies require GCIP (not available in emulator)',
       );

--- a/packages/dart_firebase_admin/test/firestore/firestore_test.dart
+++ b/packages/dart_firebase_admin/test/firestore/firestore_test.dart
@@ -135,7 +135,7 @@ void main() {
         () {
           // This test requires GOOGLE_APPLICATION_CREDENTIALS to be set
           // or running in a GCP environment
-          if (!hasGoogleEnv) {
+          if (!hasProdEnv) {
             return;
           }
 

--- a/packages/dart_firebase_admin/test/helpers.dart
+++ b/packages/dart_firebase_admin/test/helpers.dart
@@ -25,10 +25,15 @@ google_cloud_firestore.Settings mockFirestoreSettingsWithDb(
   environmentOverride: const {'FIRESTORE_EMULATOR_HOST': 'localhost:8080'},
 );
 
-/// Whether Google Application Default Credentials are available.
-/// Used to skip tests that require production Firebase access.
-final hasGoogleEnv =
+/// Whether any Google credentials are available (including WIF/external_account).
+/// Gates WIF-specific tests that run in both CI and local environments.
+final hasWifEnv =
     Platform.environment['GOOGLE_APPLICATION_CREDENTIALS'] != null;
+
+/// Whether quota-heavy production tests should run.
+/// Never set in CI — opt in locally by exporting RUN_PROD_TESTS=true alongside
+/// a service-account credential in GOOGLE_APPLICATION_CREDENTIALS.
+final hasProdEnv = Platform.environment['RUN_PROD_TESTS'] == 'true';
 
 /// Returns a copy of [Platform.environment] with all emulator host variables
 /// removed, so tests can connect to production Firebase even when emulators

--- a/packages/dart_firebase_admin/test/messaging/messaging_integration_test.dart
+++ b/packages/dart_firebase_admin/test/messaging/messaging_integration_test.dart
@@ -140,7 +140,7 @@ void main() {
         );
       });
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Requires Application Default Credentials (gcloud auth application-default login)',
   );
@@ -263,7 +263,7 @@ void main() {
         );
       });
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Requires Application Default Credentials (gcloud auth application-default login)',
   );

--- a/packages/dart_firebase_admin/test/security_rules/security_rules_integration_prod_test.dart
+++ b/packages/dart_firebase_admin/test/security_rules/security_rules_integration_prod_test.dart
@@ -61,7 +61,7 @@ void main() {
           ),
         );
       },
-      skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
     );
 
     test(
@@ -95,7 +95,7 @@ void main() {
         expect(metadata2.rulesets.single.name, isNot(ruleset2.name));
         expect(metadata2.rulesets.single.name, ruleset.name);
       },
-      skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
     );
 
     test(
@@ -115,7 +115,7 @@ void main() {
         final after = await securityRules.getFirestoreRuleset();
         expect(after.name, ruleset.name);
       },
-      skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+      skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
     );
 
     test(
@@ -160,7 +160,7 @@ void main() {
             ),
           );
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
 
       test(
@@ -177,7 +177,7 @@ void main() {
             ),
           );
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
 
       test(
@@ -199,7 +199,7 @@ void main() {
             ),
           );
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
 
       test(
@@ -217,7 +217,7 @@ void main() {
             ),
           );
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
 
       test(
@@ -234,7 +234,7 @@ void main() {
             ),
           );
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
       );
     });
   });

--- a/packages/dart_firebase_admin/test/storage/storage_prod_test.dart
+++ b/packages/dart_firebase_admin/test/storage/storage_prod_test.dart
@@ -50,7 +50,7 @@ void main() {
             expect(response.body, uploadedContent);
           }, zoneValues: {envSymbol: prodEnv()});
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
         timeout: const Timeout(Duration(seconds: 30)),
       );
 
@@ -89,7 +89,7 @@ void main() {
             expect(response.body, uploadedContent);
           }, zoneValues: {envSymbol: prodEnv()});
         },
-        skip: hasGoogleEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
+        skip: hasProdEnv ? false : 'Requires GOOGLE_APPLICATION_CREDENTIALS',
         timeout: const Timeout(Duration(seconds: 30)),
       );
     });

--- a/packages/google_cloud_firestore/test/explain_prod_test.dart
+++ b/packages/google_cloud_firestore/test/explain_prod_test.dart
@@ -197,7 +197,7 @@ void main() {
         }, zoneValues: {envSymbol: <String, String>{}});
       });
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Explain APIs require production Firestore (not supported in emulator)',
   );
@@ -369,7 +369,7 @@ void main() {
         }, zoneValues: {envSymbol: <String, String>{}});
       });
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Explain APIs require production Firestore (not supported in emulator)',
   );

--- a/packages/google_cloud_firestore/test/helpers.dart
+++ b/packages/google_cloud_firestore/test/helpers.dart
@@ -6,10 +6,10 @@ import 'package:test/test.dart';
 
 const projectId = 'dart-firebase-admin';
 
-/// Whether Google Application Default Credentials are available.
-/// Used to skip tests that require production Firebase access.
-final hasGoogleEnv =
-    Platform.environment['GOOGLE_APPLICATION_CREDENTIALS'] != null;
+/// Whether quota-heavy production tests should run.
+/// Never set in CI — opt in locally by exporting RUN_PROD_TESTS=true alongside
+/// a service-account credential in GOOGLE_APPLICATION_CREDENTIALS.
+final hasProdEnv = Platform.environment['RUN_PROD_TESTS'] == 'true';
 
 /// Whether the Firestore emulator is enabled.
 bool isFirestoreEmulatorEnabled() {

--- a/packages/google_cloud_firestore/test/query_partition_prod_test.dart
+++ b/packages/google_cloud_firestore/test/query_partition_prod_test.dart
@@ -458,7 +458,7 @@ void main() {
         },
       );
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Partition queries require production Firestore (not supported in emulator)',
   );

--- a/packages/google_cloud_firestore/test/vector_integration_prod_test.dart
+++ b/packages/google_cloud_firestore/test/vector_integration_prod_test.dart
@@ -71,7 +71,7 @@ void main() {
         });
       });
     },
-    skip: hasGoogleEnv
+    skip: hasProdEnv
         ? false
         : 'Vector search and embedding require production Firestore '
               '(not supported in emulator',

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -3,10 +3,12 @@
 # Fast fail the script on failures.
 set -e
 
-# Uncomment these to run prod tests locally, CI doesn't have service-account-key.json
-# (service account credentials) only application default credentials and uses gcloud auth login.
-# export FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+# To run production tests locally, set both of these:
 # export GOOGLE_APPLICATION_CREDENTIALS=service-account-key.json
+# export RUN_PROD_TESTS=true
+#
+# RUN_PROD_TESTS is intentionally never set in CI to avoid quota-heavy tests running there.
+# WIF tests (gated by hasWifEnv) still run in CI via the google-github-actions/auth step.
 
 # Get the script's directory and the package directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/firestore-coverage.sh
+++ b/scripts/firestore-coverage.sh
@@ -3,10 +3,11 @@
 # Fast fail the script on failures.
 set -e
 
-# Uncomment these to run prod tests locally, CI doesn't have service-account-key.json
-# (service account credentials) only application default credentials and uses gcloud auth login.
-# export FIRESTORE_EMULATOR_HOST=localhost:8080
+# To run production tests locally, set both of these:
 # export GOOGLE_APPLICATION_CREDENTIALS=service-account-key.json
+# export RUN_PROD_TESTS=true
+#
+# RUN_PROD_TESTS is intentionally never set in CI to avoid quota-heavy tests running there.
 
 # Get the script's directory and the package directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
Adds Workload Identity Federation (WIF) support to CI via google-github-actions/auth, replacing the previous service account key approach. Introduces hasWifEnv to gate WIF-specific tests that run in CI, and hasProdEnv (RUN_PROD_TESTS=true) as an explicit opt-in for quota-heavy production tests that should only run locally. Fixes a pre-existing issue where mock-credential tests were incorrectly skipped behind a credentials guard.