### PR TITLE
chore: update copyright headers to Google LLC

### DIFF
--- a/header_template.txt
+++ b/header_template.txt
@@ -1,4 +1,4 @@
-Copyright 2026 Firebase
+Copyright 2026 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/app_check_example.dart
+++ b/packages/dart_firebase_admin/example/lib/app_check_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/auth_example.dart
+++ b/packages/dart_firebase_admin/example/lib/auth_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/firestore_example.dart
+++ b/packages/dart_firebase_admin/example/lib/firestore_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/functions_example.dart
+++ b/packages/dart_firebase_admin/example/lib/functions_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/main.dart
+++ b/packages/dart_firebase_admin/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/messaging_example.dart
+++ b/packages/dart_firebase_admin/example/lib/messaging_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/security_rules_example.dart
+++ b/packages/dart_firebase_admin/example/lib/security_rules_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example/lib/storage_example.dart
+++ b/packages/dart_firebase_admin/example/lib/storage_example.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example_server_app/Dockerfile
+++ b/packages/dart_firebase_admin/example_server_app/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example_server_app/bin/server.dart
+++ b/packages/dart_firebase_admin/example_server_app/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/example_server_app/test/server_test.dart
+++ b/packages/dart_firebase_admin/example_server_app/test/server_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/app_check.dart
+++ b/packages/dart_firebase_admin/lib/app_check.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/auth.dart
+++ b/packages/dart_firebase_admin/lib/auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/dart_firebase_admin.dart
+++ b/packages/dart_firebase_admin/lib/dart_firebase_admin.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/firestore.dart
+++ b/packages/dart_firebase_admin/lib/firestore.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/functions.dart
+++ b/packages/dart_firebase_admin/lib/functions.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/messaging.dart
+++ b/packages/dart_firebase_admin/lib/messaging.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/security_rules.dart
+++ b/packages/dart_firebase_admin/lib/security_rules.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app.dart
+++ b/packages/dart_firebase_admin/lib/src/app.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/app_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/app/app_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/app_options.dart
+++ b/packages/dart_firebase_admin/lib/src/app/app_options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/app_registry.dart
+++ b/packages/dart_firebase_admin/lib/src/app/app_registry.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/credential.dart
+++ b/packages/dart_firebase_admin/lib/src/app/credential.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/emulator_client.dart
+++ b/packages/dart_firebase_admin/lib/src/app/emulator_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/environment.dart
+++ b/packages/dart_firebase_admin/lib/src/app/environment.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/exception.dart
+++ b/packages/dart_firebase_admin/lib/src/app/exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/firebase_app.dart
+++ b/packages/dart_firebase_admin/lib/src/app/firebase_app.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/firebase_service.dart
+++ b/packages/dart_firebase_admin/lib/src/app/firebase_service.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app/firebase_user_agent_client.dart
+++ b/packages/dart_firebase_admin/lib/src/app/firebase_user_agent_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/app_check.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/app_check.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/app_check_api.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/app_check_api.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/app_check_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/app_check_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/app_check_http_client.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/app_check_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/app_check_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/app_check_request_handler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/token_generator.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/token_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/app_check/token_verifier.dart
+++ b/packages/dart_firebase_admin/lib/src/app_check/token_verifier.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth.dart
+++ b/packages/dart_firebase_admin/lib/src/auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/action_code_settings_builder.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/action_code_settings_builder.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/auth.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/auth_config.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_config.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/auth_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/auth_http_client.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/auth_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_request_handler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/base_auth.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/base_auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/identifier.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/identifier.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/token_generator.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/token_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/token_verifier.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/user.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/user.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/auth/user_import_builder.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/user_import_builder.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/firestore/firestore.dart
+++ b/packages/dart_firebase_admin/lib/src/firestore/firestore.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/functions.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/functions.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/functions_api.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/functions_api.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/functions_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/functions_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/functions_http_client.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/functions_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/functions_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/functions_request_handler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/functions/task_queue.dart
+++ b/packages/dart_firebase_admin/lib/src/functions/task_queue.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/messaging/fmc_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/fmc_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/messaging/messaging.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging_api.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/messaging/messaging_http_client.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/messaging/messaging_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/messaging/messaging_request_handler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/object_utils.dart
+++ b/packages/dart_firebase_admin/lib/src/object_utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/security_rules/security_rules.dart
+++ b/packages/dart_firebase_admin/lib/src/security_rules/security_rules.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/security_rules/security_rules_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/security_rules/security_rules_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/security_rules/security_rules_http_client.dart
+++ b/packages/dart_firebase_admin/lib/src/security_rules/security_rules_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/security_rules/security_rules_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/security_rules/security_rules_request_handler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/storage/storage.dart
+++ b/packages/dart_firebase_admin/lib/src/storage/storage.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/storage/storage_exception.dart
+++ b/packages/dart_firebase_admin/lib/src/storage/storage_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/app_extension.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/error.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/error.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/index.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/index.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/jwt.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/jwt.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/native_environment.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/native_environment.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/utils.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/src/utils/validator.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/validator.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/lib/storage.dart
+++ b/packages/dart_firebase_admin/lib/storage.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/fixtures/auth/helpers.dart
+++ b/packages/dart_firebase_admin/test/fixtures/auth/helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/fixtures/functions/helpers.dart
+++ b/packages/dart_firebase_admin/test/fixtures/functions/helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/fixtures/helpers.dart
+++ b/packages/dart_firebase_admin/test/fixtures/helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/fixtures/mock.dart
+++ b/packages/dart_firebase_admin/test/fixtures/mock.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/fixtures/mock_service_account.dart
+++ b/packages/dart_firebase_admin/test/fixtures/mock_service_account.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/app/firebase_app_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/app/firebase_app_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/app/firebase_app_test.dart
+++ b/packages/dart_firebase_admin/test/integration/app/firebase_app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/app_check/app_check_test.dart
+++ b/packages/dart_firebase_admin/test/integration/app_check/app_check_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/auth_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/auth_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/auth_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/auth_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/project_config_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/project_config_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/project_config_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/project_config_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/tenant_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/tenant_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/auth/tenant_test.dart
+++ b/packages/dart_firebase_admin/test/integration/auth/tenant_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/firestore/firestore_test.dart
+++ b/packages/dart_firebase_admin/test/integration/firestore/firestore_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/functions/functions_test.dart
+++ b/packages/dart_firebase_admin/test/integration/functions/functions_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/messaging/messaging_test.dart
+++ b/packages/dart_firebase_admin/test/integration/messaging/messaging_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/security_rules/security_rules_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/security_rules/security_rules_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/storage/storage_prod_test.dart
+++ b/packages/dart_firebase_admin/test/integration/storage/storage_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/integration/storage/storage_test.dart
+++ b/packages/dart_firebase_admin/test/integration/storage/storage_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/app_registry_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/app_registry_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/credential_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/credential_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/exception_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/exception_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/firebase_admin_app_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/firebase_admin_app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/firebase_app_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/firebase_app_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app/firebase_user_agent_client_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app/firebase_user_agent_client_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app_check/app_check_exception_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app_check/app_check_exception_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app_check/app_check_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app_check/app_check_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/app_check/token_verifier_test.dart
+++ b/packages/dart_firebase_admin/test/unit/app_check/token_verifier_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/auth_config_tenant_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/auth_config_tenant_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/auth_exception_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/auth_exception_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/auth_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/auth_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/jwt_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/jwt_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/project_config_manager_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/project_config_manager_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/project_config_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/project_config_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/tenant_manager_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/tenant_manager_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/tenant_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/tenant_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/token_verifier_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/token_verifier_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/auth/user_test.dart
+++ b/packages/dart_firebase_admin/test/unit/auth/user_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/firestore/firestore_test.dart
+++ b/packages/dart_firebase_admin/test/unit/firestore/firestore_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/functions/functions_test.dart
+++ b/packages/dart_firebase_admin/test/unit/functions/functions_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/messaging/messaging_test.dart
+++ b/packages/dart_firebase_admin/test/unit/messaging/messaging_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/security_rules/security_rules_test.dart
+++ b/packages/dart_firebase_admin/test/unit/security_rules/security_rules_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/dart_firebase_admin/test/unit/storage/storage_test.dart
+++ b/packages/dart_firebase_admin/test/unit/storage/storage_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/google_cloud_firestore.dart
+++ b/packages/google_cloud_firestore/lib/google_cloud_firestore.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/aggregate.dart
+++ b/packages/google_cloud_firestore/lib/src/aggregate.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/backoff.dart
+++ b/packages/google_cloud_firestore/lib/src/backoff.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/bulk_writer.dart
+++ b/packages/google_cloud_firestore/lib/src/bulk_writer.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/collection_group.dart
+++ b/packages/google_cloud_firestore/lib/src/collection_group.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/convert.dart
+++ b/packages/google_cloud_firestore/lib/src/convert.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/credential.dart
+++ b/packages/google_cloud_firestore/lib/src/credential.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/document.dart
+++ b/packages/google_cloud_firestore/lib/src/document.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/document_change.dart
+++ b/packages/google_cloud_firestore/lib/src/document_change.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/document_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/document_reader.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/environment.dart
+++ b/packages/google_cloud_firestore/lib/src/environment.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/field_value.dart
+++ b/packages/google_cloud_firestore/lib/src/field_value.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/filter.dart
+++ b/packages/google_cloud_firestore/lib/src/filter.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/firestore.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/firestore_exception.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_exception.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/geo_point.dart
+++ b/packages/google_cloud_firestore/lib/src/geo_point.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/logger.dart
+++ b/packages/google_cloud_firestore/lib/src/logger.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/order.dart
+++ b/packages/google_cloud_firestore/lib/src/order.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/path.dart
+++ b/packages/google_cloud_firestore/lib/src/path.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/query_partition.dart
+++ b/packages/google_cloud_firestore/lib/src/query_partition.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/query_profile.dart
+++ b/packages/google_cloud_firestore/lib/src/query_profile.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/query_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/query_reader.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/rate_limiter.dart
+++ b/packages/google_cloud_firestore/lib/src/rate_limiter.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/recursive_delete.dart
+++ b/packages/google_cloud_firestore/lib/src/recursive_delete.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/aggregate_query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/aggregate_query.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/aggregate_query_snapshot.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/aggregate_query_snapshot.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/collection_reference.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/collection_reference.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/composite_filter_internal.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/composite_filter_internal.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/constants.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/constants.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/document_reference.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/document_reference.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/field_filter_internal.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/field_filter_internal.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/field_order.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/field_order.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/filter_internal.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/filter_internal.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/query_options.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query_options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/query_snapshot.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query_snapshot.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/query_util.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query_util.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/types.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/types.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/vector_query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/vector_query.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/vector_query_options.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/vector_query_options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/reference/vector_query_snapshot.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/vector_query_snapshot.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/serializer.dart
+++ b/packages/google_cloud_firestore/lib/src/serializer.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/set_options.dart
+++ b/packages/google_cloud_firestore/lib/src/set_options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/status_code.dart
+++ b/packages/google_cloud_firestore/lib/src/status_code.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/timestamp.dart
+++ b/packages/google_cloud_firestore/lib/src/timestamp.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/transaction.dart
+++ b/packages/google_cloud_firestore/lib/src/transaction.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/types.dart
+++ b/packages/google_cloud_firestore/lib/src/types.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/util.dart
+++ b/packages/google_cloud_firestore/lib/src/util.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/validate.dart
+++ b/packages/google_cloud_firestore/lib/src/validate.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/lib/src/write_batch.dart
+++ b/packages/google_cloud_firestore/lib/src/write_batch.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/fixtures/helpers.dart
+++ b/packages/google_cloud_firestore/test/fixtures/helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/bulk_writer_test.dart
+++ b/packages/google_cloud_firestore/test/integration/bulk_writer_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/bundle_test.dart
+++ b/packages/google_cloud_firestore/test/integration/bundle_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/explain_prod_test.dart
+++ b/packages/google_cloud_firestore/test/integration/explain_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/firestore_test.dart
+++ b/packages/google_cloud_firestore/test/integration/firestore_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/query_partition_prod_test.dart
+++ b/packages/google_cloud_firestore/test/integration/query_partition_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/recursive_delete_test.dart
+++ b/packages/google_cloud_firestore/test/integration/recursive_delete_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/set_options_test.dart
+++ b/packages/google_cloud_firestore/test/integration/set_options_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/vector_prod_test.dart
+++ b/packages/google_cloud_firestore/test/integration/vector_prod_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/integration/vector_test.dart
+++ b/packages/google_cloud_firestore/test/integration/vector_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/aggregate_query_test.dart
+++ b/packages/google_cloud_firestore/test/unit/aggregate_query_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/backoff_test.dart
+++ b/packages/google_cloud_firestore/test/unit/backoff_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/bulk_writer_test.dart
+++ b/packages/google_cloud_firestore/test/unit/bulk_writer_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/bundle_test.dart
+++ b/packages/google_cloud_firestore/test/unit/bundle_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/collection_group_test.dart
+++ b/packages/google_cloud_firestore/test/unit/collection_group_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/collection_test.dart
+++ b/packages/google_cloud_firestore/test/unit/collection_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/document_test.dart
+++ b/packages/google_cloud_firestore/test/unit/document_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/field_value_test.dart
+++ b/packages/google_cloud_firestore/test/unit/field_value_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/filter_test.dart
+++ b/packages/google_cloud_firestore/test/unit/filter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/firestore_test.dart
+++ b/packages/google_cloud_firestore/test/unit/firestore_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/get_all_test.dart
+++ b/packages/google_cloud_firestore/test/unit/get_all_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/order_test.dart
+++ b/packages/google_cloud_firestore/test/unit/order_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/query_partition_test.dart
+++ b/packages/google_cloud_firestore/test/unit/query_partition_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/query_test.dart
+++ b/packages/google_cloud_firestore/test/unit/query_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/rate_limiter_test.dart
+++ b/packages/google_cloud_firestore/test/unit/rate_limiter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/recursive_delete_test.dart
+++ b/packages/google_cloud_firestore/test/unit/recursive_delete_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/timestamp_test.dart
+++ b/packages/google_cloud_firestore/test/unit/timestamp_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/transaction_aggregation_test.dart
+++ b/packages/google_cloud_firestore/test/unit/transaction_aggregation_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/transaction_test.dart
+++ b/packages/google_cloud_firestore/test/unit/transaction_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/vector_test.dart
+++ b/packages/google_cloud_firestore/test/unit/vector_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/google_cloud_firestore/test/unit/write_batch_test.dart
+++ b/packages/google_cloud_firestore/test/unit/write_batch_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Align header template and source file copyright owner text with legal guidance by replacing "Copyright 2026 Firebase" with "Copyright 2026 Google LLC" across the repository.