### PR TITLE
doc(dart_firebase_admin): s/undefined/null

### DIFF
--- a/packages/dart_firebase_admin/lib/src/auth/auth_request_handler.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/auth_request_handler.dart
@@ -420,7 +420,7 @@ abstract class _AbstractAuthRequestHandler {
   /// Exports the users (single batch only) with a size of maxResults and starting from
   /// the offset as specified by pageToken.
   ///
-  /// maxResults - The page size, 1000 if undefined. This is also the maximum
+  /// maxResults - The page size, 1000 if not specified. This is also the maximum
   /// allowed limit.
   ///
   /// pageToken - The next page token. If not specified, returns users starting

--- a/packages/dart_firebase_admin/lib/src/auth/base_auth.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/base_auth.dart
@@ -503,7 +503,7 @@ abstract class _BaseAuth {
   /// See https://firebase.google.com/docs/auth/admin/manage-users#list_all_users
   /// for code samples and detailed documentation.
   ///
-  /// - maxResults - The page size, 1000 if undefined. This is also
+  /// - maxResults - The page size, 1000 if not specified. This is also
   ///   the maximum allowed limit.
   /// - pageToken - The next page token. If not specified, returns
   ///   users starting without any offset.

--- a/packages/dart_firebase_admin/lib/src/auth/tenant.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/tenant.dart
@@ -112,7 +112,7 @@ class Tenant {
     try {
       emailSignInConfig = _EmailSignInConfig.fromServerResponse(response);
     } catch (e) {
-      // If allowPasswordSignup is undefined, it is disabled by default.
+      // If allowPasswordSignup is `null`, it is disabled by default.
       emailSignInConfig = _EmailSignInConfig(
         enabled: false,
         passwordRequired: true,

--- a/packages/dart_firebase_admin/lib/src/auth/tenant_manager.dart
+++ b/packages/dart_firebase_admin/lib/src/auth/tenant_manager.dart
@@ -226,7 +226,7 @@ class TenantManager {
   /// starting from the offset as specified by [pageToken]. This is used to
   /// retrieve all the tenants of a specified project in batches.
   ///
-  /// [maxResults] - The page size, 1000 if undefined. This is also
+  /// [maxResults] - The page size, 1000 if not specified. This is also
   ///   the maximum allowed limit.
   /// [pageToken] - The next page token. If not specified, returns
   ///   tenants starting without any offset.

--- a/packages/dart_firebase_admin/lib/src/utils/utils.dart
+++ b/packages/dart_firebase_admin/lib/src/utils/utils.dart
@@ -19,7 +19,7 @@ String get dartVersion =>
     Platform.version.split(RegExp('[^0-9]')).take(3).join('.');
 
 /// Generates the update mask for the provided object.
-/// Note this will ignore the last key with value undefined.
+/// Note this will ignore the last key with value `null`.
 List<String> generateUpdateMask(
   Object? obj, {
   List<String> terminalPaths = const [],

--- a/packages/google_cloud_firestore/lib/src/document.dart
+++ b/packages/google_cloud_firestore/lib/src/document.dart
@@ -203,7 +203,7 @@ class DocumentSnapshot<T> {
   ///
   /// final documentSnapshot = await documentRef.get();
   /// final data = documentSnapshot.data();
-  /// print('Retrieved data: ${JSON.stringify(data)}');
+  /// print('Retrieved data: ${jsonEncode(data)}');
   /// ```
   T? data() {
     final fieldsProto = _fieldsProto;

--- a/packages/google_cloud_firestore/lib/src/document.dart
+++ b/packages/google_cloud_firestore/lib/src/document.dart
@@ -23,8 +23,8 @@ class Optional<T> {
 /// Firestore database. The data can be extracted with [data].
 ///
 /// For a DocumentSnapshot that points to a non-existing document, any data
-/// access will return 'undefined'. You can use the
-/// [exists] property to explicitly verify a document's existence.
+/// access will return `null`. You can use the [exists] property to explicitly
+/// verify a document's existence.
 @immutable
 class DocumentSnapshot<T> {
   const DocumentSnapshot._({
@@ -195,19 +195,15 @@ class DocumentSnapshot<T> {
   /// ```
   bool get exists => _fieldsProto != null;
 
-  /// Retrieves all fields in the document as an object. Returns 'undefined' if
+  /// Retrieves all fields in the document as an object. Returns `null` if
   /// the document doesn't exist.
-  ///
-  /// Returns an object containing all fields in the document or
-  /// 'null' if the document doesn't exist.
   ///
   /// ```dart
   /// final documentRef = firestore.doc('col/doc');
   ///
-  /// documentRef.get().then((documentSnapshot) {
-  ///   final data = documentSnapshot.data();
-  ///   print('Retrieved data: ${JSON.stringify(data)}');
-  /// });
+  /// final documentSnapshot = await documentRef.get();
+  /// final data = documentSnapshot.data();
+  /// print('Retrieved data: ${JSON.stringify(data)}');
   /// ```
   T? data() {
     final fieldsProto = _fieldsProto;


### PR DESCRIPTION
Removes the use of `undefined` in dartdoc (`undefined` is not a type in Dart).
