### PR TITLE
fix: support string sound and interruption-level in APNs Aps payload

### DIFF
--- a/packages/firebase_admin_sdk/example/lib/messaging_example.dart
+++ b/packages/firebase_admin_sdk/example/lib/messaging_example.dart
@@ -166,7 +166,7 @@ Future<void> messagingExample(FirebaseApp admin) async {
           payload: ApnsPayload(
             aps: Aps(
               contentAvailable: true,
-              sound: CriticalSound(critical: true, name: 'default'),
+              sound: const CriticalSound(critical: true, name: 'default'),
             ),
           ),
         ),

--- a/packages/firebase_admin_sdk/lib/src/messaging/messaging_api.dart
+++ b/packages/firebase_admin_sdk/lib/src/messaging/messaging_api.dart
@@ -449,6 +449,7 @@ class Aps {
     this.mutableContent,
     this.category,
     this.threadId,
+    this.interruptionLevel,
   });
 
   /// Alert to be included in the message. This may be a string or an object of
@@ -459,8 +460,9 @@ class Aps {
   /// not specified, the badge will remain unchanged.
   final num? badge;
 
-  /// Sound to be played with the message.
-  final CriticalSound? sound;
+  /// Sound to be played with the message. May be a simple sound name via
+  /// [ApsSoundName] or a critical alert configuration via [CriticalSound].
+  final ApsSound? sound;
 
   /// Specifies whether to configure a background update notification.
   final bool? contentAvailable;
@@ -475,15 +477,20 @@ class Aps {
   /// An app-specific identifier for grouping notifications.
   final String? threadId;
 
+  /// The interruption level of the notification.
+  final ApsInterruptionLevel? interruptionLevel;
+
   Map<String, Object?> _toRequest() {
     return {
       if (alert != null) 'alert': alert?._toRequest(),
       if (badge != null) 'badge': badge,
-      if (sound != null) 'sound': sound?._toRequest(),
+      if (sound != null) 'sound': sound!._toRequest(),
       if (contentAvailable != null) 'content-available': contentAvailable,
       if (mutableContent != null) 'mutable-content': mutableContent,
       if (category != null) 'category': category,
       if (threadId != null) 'thread-id': threadId,
+      if (interruptionLevel != null)
+        'interruption-level': interruptionLevel!._value,
     }.toCleanRequest();
   }
 }
@@ -532,9 +539,64 @@ class ApsAlert {
   }
 }
 
+/// The interruption level of an APNs notification, as defined by Apple.
+///
+/// See https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel
+enum ApsInterruptionLevel {
+  /// The system presents the notification immediately, lights up the screen,
+  /// and can play a sound.
+  active,
+
+  /// The system presents the notification immediately, lights up the screen,
+  /// and bypasses the mute switch to play a sound. Requires the Critical Alerts
+  /// entitlement.
+  critical,
+
+  /// The system adds the notification to the notification list without lighting
+  /// up the screen or playing a sound.
+  passive,
+
+  /// The notification appears immediately and can play a sound, but will not
+  /// break through Focus or Do Not Disturb.
+  timeSensitive;
+
+  String get _value => switch (this) {
+    ApsInterruptionLevel.active => 'active',
+    ApsInterruptionLevel.critical => 'critical',
+    ApsInterruptionLevel.passive => 'passive',
+    ApsInterruptionLevel.timeSensitive => 'time-sensitive',
+  };
+}
+
+/// Base class for the APNs `sound` field.
+///
+/// Use [ApsSoundName] for a simple sound file name, or [CriticalSound] for a
+/// critical alert sound configuration.
+sealed class ApsSound {
+  const ApsSound();
+  Object _toRequest();
+}
+
+/// A simple sound name for an APNs notification.
+///
+/// Use `"default"` to play the system sound, or provide the filename of a
+/// sound resource bundled in the app.
+final class ApsSoundName extends ApsSound {
+  const ApsSoundName(this.name);
+
+  /// The name of the sound file to play.
+  final String name;
+
+  @override
+  String _toRequest() => name;
+}
+
 /// Represents a critical sound configuration that can be included in the
 /// `aps` dictionary of an APNs payload.
-class CriticalSound {
+///
+/// Requires the Critical Alerts entitlement. For a simple sound name, use
+/// [ApsSoundName] instead.
+final class CriticalSound extends ApsSound {
   CriticalSound({this.critical, required this.name, this.volume});
 
   /// The critical alert flag. Set to `true` to enable the critical alert.
@@ -549,6 +611,7 @@ class CriticalSound {
   /// (silent) and 1.0 (full volume).
   final double? volume;
 
+  @override
   Map<String, Object?> _toRequest() {
     return {
       'critical': critical,

--- a/packages/firebase_admin_sdk/lib/src/messaging/messaging_api.dart
+++ b/packages/firebase_admin_sdk/lib/src/messaging/messaging_api.dart
@@ -482,15 +482,14 @@ class Aps {
 
   Map<String, Object?> _toRequest() {
     return {
-      if (alert != null) 'alert': alert?._toRequest(),
-      if (badge != null) 'badge': badge,
-      if (sound != null) 'sound': sound!._toRequest(),
-      if (contentAvailable != null) 'content-available': contentAvailable,
-      if (mutableContent != null) 'mutable-content': mutableContent,
-      if (category != null) 'category': category,
-      if (threadId != null) 'thread-id': threadId,
-      if (interruptionLevel != null)
-        'interruption-level': interruptionLevel!._value,
+      'alert': ?alert?._toRequest(),
+      'badge': ?badge,
+      'sound': ?sound?._toRequest(),
+      'content-available': ?contentAvailable,
+      'mutable-content': ?mutableContent,
+      'category': ?category,
+      'thread-id': ?threadId,
+      'interruption-level': ?interruptionLevel?._value,
     }.toCleanRequest();
   }
 }
@@ -597,7 +596,7 @@ final class ApsSoundName extends ApsSound {
 /// Requires the Critical Alerts entitlement. For a simple sound name, use
 /// [ApsSoundName] instead.
 final class CriticalSound extends ApsSound {
-  CriticalSound({this.critical, required this.name, this.volume});
+  const CriticalSound({this.critical, required this.name, this.volume});
 
   /// The critical alert flag. Set to `true` to enable the critical alert.
   final bool? critical;

--- a/packages/firebase_admin_sdk/test/integration/messaging/messaging_test.dart
+++ b/packages/firebase_admin_sdk/test/integration/messaging/messaging_test.dart
@@ -159,6 +159,32 @@ void main() {
         },
       );
 
+      test(
+        'send() with ApsSoundName and ApsInterruptionLevel is accepted by FCM',
+        () async {
+          final messageId = await messaging.send(
+            TopicMessage(
+              topic: 'foo-bar',
+              notification: Notification(
+                title: 'Integration Test',
+                body: 'Testing APNs sound and interruption level',
+              ),
+              apns: ApnsConfig(
+                payload: ApnsPayload(
+                  aps: Aps(
+                    sound: const ApsSoundName('default'),
+                    interruptionLevel: ApsInterruptionLevel.timeSensitive,
+                  ),
+                ),
+              ),
+            ),
+            dryRun: true,
+          );
+
+          expect(messageId, matches(RegExp(r'^projects/.*/messages/.*$')));
+        },
+      );
+
       test('sendEach() validates empty messages list', () async {
         await expectLater(
           () => messaging.sendEach([]),

--- a/packages/firebase_admin_sdk/test/unit/messaging/messaging_test.dart
+++ b/packages/firebase_admin_sdk/test/unit/messaging/messaging_test.dart
@@ -272,7 +272,7 @@ void main() {
               aps: Aps(
                 contentAvailable: true,
                 mutableContent: true,
-                sound: CriticalSound(critical: true, name: 'default'),
+                sound: const CriticalSound(critical: true, name: 'default'),
               ),
             ),
           ),

--- a/packages/firebase_admin_sdk/test/unit/messaging/messaging_test.dart
+++ b/packages/firebase_admin_sdk/test/unit/messaging/messaging_test.dart
@@ -306,6 +306,72 @@ void main() {
       expect(request.message!.webpush!.notification!['renotify'], 1);
     });
 
+    test('ApsSoundName serialises as a plain string', () async {
+      when(
+        () => messages.send(any(), any()),
+      ).thenAnswer((_) => Future.value(fmc1.Message(name: 'test')));
+
+      await messaging.send(
+        TopicMessage(
+          topic: 'test',
+          apns: ApnsConfig(
+            payload: ApnsPayload(
+              aps: Aps(sound: const ApsSoundName('default')),
+            ),
+          ),
+        ),
+      );
+
+      final capture = verify(() => messages.send(captureAny(), captureAny()))
+        ..called(1);
+      final request = capture.captured.first as fmc1.SendMessageRequest;
+
+      expect(
+        request.message!.apns!.payload!['aps']
+            .cast<Map<Object?, Object?>>()['sound'],
+        'default',
+      );
+    });
+
+    test(
+      'ApsInterruptionLevel serialises with correct APNs key values',
+      () async {
+        for (final (level, expected) in [
+          (ApsInterruptionLevel.active, 'active'),
+          (ApsInterruptionLevel.critical, 'critical'),
+          (ApsInterruptionLevel.passive, 'passive'),
+          (ApsInterruptionLevel.timeSensitive, 'time-sensitive'),
+        ]) {
+          when(
+            () => messages.send(any(), any()),
+          ).thenAnswer((_) => Future.value(fmc1.Message(name: 'test')));
+
+          await messaging.send(
+            TopicMessage(
+              topic: 'test',
+              apns: ApnsConfig(
+                payload: ApnsPayload(aps: Aps(interruptionLevel: level)),
+              ),
+            ),
+          );
+
+          final capture = verify(
+            () => messages.send(captureAny(), captureAny()),
+          )..called(1);
+          final request = capture.captured.first as fmc1.SendMessageRequest;
+
+          expect(
+            request.message!.apns!.payload!['aps']
+                .cast<Map<Object?, Object?>>()['interruption-level'],
+            expected,
+            reason: 'Expected $level to serialise as "$expected"',
+          );
+
+          reset(messages);
+        }
+      },
+    );
+
     test('supports null alert/sound', () async {
       when(
         () => messages.send(any(), any()),


### PR DESCRIPTION
Fixes #80

## Problem

`Aps.sound` was typed as `CriticalSound?`, which serialises to a sound
dictionary. This is only accepted by Firebase if the app has the Critical
Alerts entitlement. There was no way to pass a plain string for `sound`
(e.g. `"default"`), which is the correct form for standard notifications.

Additionally, the APNs `interruption-level` field was not supported at all.

## Changes

### `ApsSound` sealed class

Introduces `ApsSound` as a sealed base type for the `sound` field, matching
the Node.js Admin SDK's `string | CriticalSound` union:

- `ApsSoundName` — a plain sound file name (e.g. `ApsSoundName('default')`)
- `CriticalSound` — the existing critical alert dictionary, now a subtype of `ApsSound`

`Aps.sound` is changed from `CriticalSound?` to `ApsSound?`. Existing code
using `CriticalSound` continues to compile without changes.

### `ApsInterruptionLevel` enum

Adds a typed enum for the APNs `interruption-level` field with all four
Apple-defined values: `active`, `passive`, `timeSensitive`, `critical`.
`timeSensitive` serialises to `"time-sensitive"` as required by the spec.

### Serialisation cleanup

`Aps._toRequest()` now uses null-aware map entries (`'key': ?expr`) instead
of `if (x != null) 'key': x!` guards. This avoids the `!` operator on public
fields (which cannot be promoted in non-final classes) and is more concise.

`CriticalSound`'s constructor is now `const`.

## Usage

```dart
// Standard notification with sound (previously impossible)
Aps(
  sound: ApsSoundName('default'),
  interruptionLevel: ApsInterruptionLevel.timeSensitive,
)

// Critical alert (unchanged)
Aps(
  sound: CriticalSound(critical: true, name: 'alert.wav', volume: 1.0),
  interruptionLevel: ApsInterruptionLevel.critical,
)
```

## Testing

### Unit tests
Serialisation is verified for both `ApsSoundName` and all four
`ApsInterruptionLevel` values in `test/unit/messaging/messaging_test.dart`.

### Integration test (dryRun)
A `dryRun: true` integration test in `test/integration/messaging/messaging_test.dart`
confirms FCM accepts the payload shape.

### Manual — real device (iPhone, iOS 26)
Tested end-to-end with a Flutter app running on a physical device using a
sandbox APNs key. The notification was delivered with sound and the
**TIME SENSITIVE** banner as expected.

![Screenshot](https://github.com/user-attachments/assets/5aae943c-0fd9-44f2-9d27-bdc253dac72a)

### `CriticalSound` note
`CriticalSound` cannot be tested on a real device without Apple granting the
Critical Alerts entitlement, which requires an application to Apple and is
restricted to medical, health, and public safety apps. The unit tests are the
practical coverage ceiling for that class.