### PR TITLE
fix(firestore): support Infinity, -Infinity, and NaN double values

### DIFF
--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:google_cloud/constants.dart' as google_cloud;
 import 'package:google_cloud/google_cloud.dart' as google_cloud;
@@ -23,7 +24,88 @@ import 'package:meta/meta.dart';
 
 import '../google_cloud_firestore.dart';
 import 'environment.dart';
+import 'firestore.dart'
+    show Serializer, kInfinitySentinel, kNaNSentinel, kNegInfinitySentinel;
 import 'firestore_exception.dart';
+
+// Matches a complete Firestore Value JSON object whose doubleValue is one of
+// the three special IEEE 754 strings the REST API emits. Anchoring on the
+// surrounding braces prevents false-positive matches inside user string fields
+// that happen to contain the text `"doubleValue":"Infinity"`.
+final _specialDoublePattern = RegExp(
+  r'\{\s*"doubleValue"\s*:\s*"(Infinity|-Infinity|NaN)"\s*\}',
+);
+
+/// HTTP client wrapper that rewrites special IEEE 754 double values in
+/// Firestore REST API responses before the googleapis library parses them.
+///
+/// The Firestore REST API encodes [double.infinity], [double.negativeInfinity],
+/// and [double.nan] as the JSON strings `"Infinity"`, `"-Infinity"`, and
+/// `"NaN"` respectively (since those values are not representable in standard
+/// JSON). The googleapis-generated [firestore_v1.Value.fromJson] does a hard `as num` cast
+/// on the `doubleValue` field and therefore throws when it encounters a string.
+///
+/// This client intercepts every response body and replaces those patterns with
+/// a `stringValue` sentinel that [Serializer.decodeValue] understands.
+/// The sentinel strings are defined alongside [Serializer.decodeValue] in
+/// `serializer.dart`.
+class _SpecialDoubleClient extends BaseClient {
+  _SpecialDoubleClient(this._inner);
+
+  final Client _inner;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final response = await _inner.send(request);
+
+    final contentType = response.headers['content-type'] ?? '';
+    if (!contentType.contains('application/json')) return response;
+
+    final body = await response.stream.bytesToString();
+    if (!body.contains('"doubleValue"')) return _rebuild(response, body);
+
+    final patched = body.replaceAllMapped(_specialDoublePattern, (m) {
+      final sentinel = switch (m.group(1)) {
+        'Infinity' => kInfinitySentinel,
+        '-Infinity' => kNegInfinitySentinel,
+        _ => kNaNSentinel, // 'NaN'
+      };
+      return '{"stringValue":"$sentinel"}';
+    });
+
+    return _rebuild(response, patched);
+  }
+
+  StreamedResponse _rebuild(StreamedResponse original, String body) {
+    final bytes = utf8.encode(body);
+    final headers = Map<String, String>.from(original.headers)
+      ..['content-length'] = bytes.length.toString();
+    return StreamedResponse(
+      Stream.value(bytes),
+      original.statusCode,
+      contentLength: bytes.length,
+      headers: headers,
+      request: original.request,
+      reasonPhrase: original.reasonPhrase,
+    );
+  }
+}
+
+/// An [googleapis_auth.AuthClient] wrapper that applies [_SpecialDoubleClient]
+/// response rewriting while preserving the [credentials] required by the
+/// googleapis request pipeline.
+class _SpecialDoubleAuthClient extends _SpecialDoubleClient
+    implements googleapis_auth.AuthClient {
+  _SpecialDoubleAuthClient(this._authInner) : super(_authInner);
+
+  final googleapis_auth.AuthClient _authInner;
+
+  @override
+  googleapis_auth.AccessCredentials get credentials => _authInner.credentials;
+
+  @override
+  void close() => _authInner.close();
+}
 
 /// Internal HTTP request implementation that wraps a stream.
 ///
@@ -114,22 +196,28 @@ class FirestoreHttpClient {
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
     if (_isUsingEmulator) {
-      // Emulator: Create unauthenticated client
-      return EmulatorClient(Client());
+      // Emulator: Create unauthenticated client, wrapped to rewrite special
+      // doubles before EmulatorClient adds auth headers.
+      return EmulatorClient(_SpecialDoubleClient(Client()));
     }
 
-    // Production: Create authenticated client
+    // Production: Create authenticated client, then wrap to rewrite special
+    // doubles in responses before googleapis parses them.
     final serviceAccountCreds = credential.serviceAccountCredentials;
     if (serviceAccountCreds != null) {
-      return googleapis_auth.clientViaServiceAccount(serviceAccountCreds, [
-        firestore_v1.FirestoreApi.cloudPlatformScope,
-      ]);
+      final authClient = await googleapis_auth.clientViaServiceAccount(
+        serviceAccountCreds,
+        [firestore_v1.FirestoreApi.cloudPlatformScope],
+      );
+      return _SpecialDoubleAuthClient(authClient);
     }
 
     // Fall back to Application Default Credentials
-    return googleapis_auth.clientViaApplicationDefaultCredentials(
-      scopes: [firestore_v1.FirestoreApi.cloudPlatformScope],
-    );
+    final authClient = await googleapis_auth
+        .clientViaApplicationDefaultCredentials(
+          scopes: [firestore_v1.FirestoreApi.cloudPlatformScope],
+        );
+    return _SpecialDoubleAuthClient(authClient);
   }
 
   Future<R> _run<R>(

--- a/packages/google_cloud_firestore/lib/src/serializer.dart
+++ b/packages/google_cloud_firestore/lib/src/serializer.dart
@@ -17,8 +17,44 @@ part of 'firestore.dart';
 @internal
 typedef ApiMapValue = Map<String, firestore_v1.Value>;
 
+// Sentinel string values used to round-trip special IEEE 754 doubles through
+// the googleapis JSON deserialiser, which cannot handle non-finite doubles.
+//
+// [_SpecialDoubleClient] in firestore_http_client.dart rewrites incoming
+// Firestore REST API responses:
+//   "doubleValue":"Infinity"   →  "stringValue":"<kInfinitySentinel>"
+//   "doubleValue":"-Infinity"  →  "stringValue":"<kNegInfinitySentinel>"
+//   "doubleValue":"NaN"        →  "stringValue":"<kNaNSentinel>"
+//
+// [Serializer.decodeValue] then maps each sentinel back to the corresponding
+// Dart double constant.  The names are package-internal (no `_` prefix) so
+// that firestore_http_client.dart can reference them via its barrel import.
+@internal
+const kInfinitySentinel = '__fs_double_infinity__';
+@internal
+const kNegInfinitySentinel = '__fs_double_neg_infinity__';
+@internal
+const kNaNSentinel = '__fs_double_nan__';
+
 abstract base class _Serializable {
   firestore_v1.Value _toProto();
+}
+
+/// A [firestore_v1.Value] subclass that overrides [toJson] to emit the
+/// Firestore REST API string representations of special IEEE 754 doubles
+/// (`"Infinity"`, `"-Infinity"`, `"NaN"`).
+///
+/// Dart's [jsonEncode] (and therefore the googleapis serialiser) throws on
+/// [double.infinity] and [double.nan] because they are not valid JSON.
+/// The Firestore REST API expects them as the strings above, so we bypass
+/// standard serialisation by overriding [toJson] here.
+class _SpecialDoubleValue extends firestore_v1.Value {
+  _SpecialDoubleValue._(this._doubleString) : super();
+
+  final String _doubleString;
+
+  @override
+  Map<String, dynamic> toJson() => {'doubleValue': _doubleString};
 }
 
 class Serializer {
@@ -83,6 +119,12 @@ class Serializer {
       case BigInt():
         return firestore_v1.Value(integerValue: value.toString());
 
+      case double() when value.isInfinite:
+        return _SpecialDoubleValue._(value > 0 ? 'Infinity' : '-Infinity');
+
+      case double() when value.isNaN:
+        return _SpecialDoubleValue._('NaN');
+
       case double():
         return firestore_v1.Value(doubleValue: value);
 
@@ -140,7 +182,15 @@ class Serializer {
 
     switch (proto) {
       case firestore_v1.Value(:final stringValue?):
-        return stringValue;
+        // The HTTP response interceptor rewrites special double strings
+        // ("Infinity", "-Infinity", "NaN") as sentinel stringValues so that
+        // googleapis can parse the response without casting a String to num.
+        return switch (stringValue) {
+          kInfinitySentinel => double.infinity,
+          kNegInfinitySentinel => double.negativeInfinity,
+          kNaNSentinel => double.nan,
+          _ => stringValue,
+        };
       case firestore_v1.Value(:final booleanValue?):
         return booleanValue;
       case firestore_v1.Value(:final integerValue?):

--- a/packages/google_cloud_firestore/test/integration/firestore_test.dart
+++ b/packages/google_cloud_firestore/test/integration/firestore_test.dart
@@ -12,10 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 import '../fixtures/helpers.dart';
+
+/// Seeds a Firestore document directly via the emulator REST API, bypassing
+/// the Dart SDK's serializer. This lets us create documents with special double
+/// values (Infinity, -Infinity, NaN) that the SDK's write path currently can't
+/// encode, so we can test the read path independently.
+Future<void> _seedDocumentWithSpecialDoubles(
+  String docPath,
+  Map<String, Object?> fields,
+) async {
+  final emulatorHost = Platform.environment['FIRESTORE_EMULATOR_HOST']!;
+  final uri = Uri.http(
+    emulatorHost,
+    '/v1/projects/$projectId/databases/(default)/documents/$docPath',
+  );
+
+  final encodedFields = fields.map((key, value) {
+    final encoded = switch (value) {
+      double.infinity => {'doubleValue': 'Infinity'},
+      double.negativeInfinity => {'doubleValue': '-Infinity'},
+      _ when value is double && value.isNaN => {'doubleValue': 'NaN'},
+      _ => throw ArgumentError('Unsupported seed value: $value'),
+    };
+    return MapEntry(key, encoded);
+  });
+
+  final response = await http.patch(
+    uri,
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode({'fields': encodedFields}),
+  );
+
+  if (response.statusCode != 200) {
+    throw StateError(
+      'Failed to seed document at $docPath: '
+      '${response.statusCode} ${response.body}',
+    );
+  }
+}
 
 void main() {
   group('Firestore', () {
@@ -65,6 +107,84 @@ void main() {
           (data['agents']! as Map<String, Object?>)['products/product-b'],
           10.0,
         );
+      });
+    });
+
+    group('special IEEE 754 double values', () {
+      group('write path', () {
+        test('set() round-trips double.infinity', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await ref.set({'value': double.infinity});
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], double.infinity);
+        });
+
+        test('set() round-trips double.negativeInfinity', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await ref.set({'value': double.negativeInfinity});
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], double.negativeInfinity);
+        });
+
+        test('set() round-trips double.nan', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await ref.set({'value': double.nan});
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], isNaN);
+        });
+      });
+
+      group('read path', () {
+        test('get() decodes Infinity seeded via REST API', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await _seedDocumentWithSpecialDoubles('special-doubles/${ref.id}', {
+            'value': double.infinity,
+          });
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], double.infinity);
+        });
+
+        test('get() decodes -Infinity seeded via REST API', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await _seedDocumentWithSpecialDoubles('special-doubles/${ref.id}', {
+            'value': double.negativeInfinity,
+          });
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], double.negativeInfinity);
+        });
+
+        test('get() decodes NaN seeded via REST API', () async {
+          final ref = firestore.collection('special-doubles').doc();
+          await _seedDocumentWithSpecialDoubles('special-doubles/${ref.id}', {
+            'value': double.nan,
+          });
+
+          final data = (await ref.get()).data()!;
+          expect(data['value'], isNaN);
+        });
+      });
+
+      group('query path', () {
+        test('query results decode documents with Infinity', () async {
+          final ref = firestore.collection('special-doubles-query').doc();
+          await _seedDocumentWithSpecialDoubles(
+            'special-doubles-query/${ref.id}',
+            {'value': double.infinity},
+          );
+
+          final results = await firestore
+              .collection('special-doubles-query')
+              .get();
+
+          expect(results.docs, isNotEmpty);
+          final data = results.docs.first.data();
+          expect(data['value'], double.infinity);
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes #104

Firestore stores IEEE 754 special doubles (`Infinity`, `-Infinity`, `NaN`) as JSON strings in the REST API response (e.g. `"doubleValue":"Infinity"`), since these values are not representable in standard JSON. The `googleapis` library's `Value.fromJson` does a hard `as num` cast on `doubleValue` and throws `type 'String' is not a subtype of 'num'` when it encounters them.

The same issue exists on the write path: Dart's `jsonEncode` throws `JsonUnsupportedObjectError` when serialising `double.infinity` or `double.nan`.

- **Read path**: adds `_SpecialDoubleClient`, an HTTP response interceptor that rewrites `"doubleValue":"Infinity|−Infinity|NaN"` to a sentinel `stringValue` before `googleapis` parses the response. `Serializer.decodeValue` maps the sentinels back to the correct Dart `double` constants.
- **Write path**: adds `_SpecialDoubleValue`, a `firestore_v1.Value` subclass that overrides `toJson()` to emit the string form the REST API expects, bypassing `jsonEncode` entirely.