### PR TITLE
fix(firestore): make core Firestore classes mockable

### DIFF
--- a/packages/firebase_admin_sdk/CHANGELOG.md
+++ b/packages/firebase_admin_sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.2-wip
 
 - Remove dependency on `package:equatable`.
+- Make `Query`, `CollectionReference`, `DocumentReference`, and `CollectionGroup` mockable.
 
 ## 0.5.1
 

--- a/packages/firebase_admin_sdk/example/pubspec.yaml
+++ b/packages/firebase_admin_sdk/example/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   google_cloud_storage: ^0.6.0
 
 dev_dependencies:
-  mocktail: ^1.0.2
-  test: ^1.26.3
+  mocktail: ^1.0.5
+  test: ^1.31.0

--- a/packages/firebase_admin_sdk/example/pubspec.yaml
+++ b/packages/firebase_admin_sdk/example/pubspec.yaml
@@ -10,3 +10,7 @@ dependencies:
   firebase_admin_sdk: ^0.5.0
   google_cloud_firestore: ^0.5.0
   google_cloud_storage: ^0.6.0
+
+dev_dependencies:
+  mocktail: ^1.0.2
+  test: ^1.26.3

--- a/packages/firebase_admin_sdk/example/test/examples_test.dart
+++ b/packages/firebase_admin_sdk/example/test/examples_test.dart
@@ -16,73 +16,6 @@ import 'package:google_cloud_firestore/google_cloud_firestore.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-abstract interface class UserRepository {
-  Future<Map<String, dynamic>?> findById(String id);
-
-  Future<void> save(String id, Map<String, dynamic> data);
-
-  Future<List<Map<String, dynamic>>> findAll();
-}
-
-class FirestoreUserRepository implements UserRepository {
-  FirestoreUserRepository(this._firestore);
-
-  final Firestore _firestore;
-
-  @override
-  Future<Map<String, dynamic>?> findById(String id) async {
-    final snap = await _firestore.collection('users').doc(id).get();
-    return snap.data();
-  }
-
-  @override
-  Future<void> save(String id, Map<String, dynamic> data) {
-    return _firestore.collection('users').doc(id).set(data);
-  }
-
-  @override
-  Future<List<Map<String, dynamic>>> findAll() async {
-    final snap = await _firestore.collection('users').get();
-    return [for (final doc in snap.docs) doc.data()];
-  }
-}
-
-class UserService {
-  UserService(this._repo);
-
-  final UserRepository _repo;
-
-  Future<String?> getDisplayName(String id) async {
-    final data = await _repo.findById(id);
-    return data?['displayName'] as String?;
-  }
-
-  Future<void> createUser(String id, String displayName) {
-    return _repo.save(id, {'displayName': displayName});
-  }
-
-  Future<int> countUsers() async {
-    final users = await _repo.findAll();
-    return users.length;
-  }
-}
-
-class ReportService {
-  Future<int> countMatchingDocuments(Query<Map<String, dynamic>> query) async {
-    final snap = await query.get();
-    return snap.size;
-  }
-
-  Future<List<Map<String, dynamic>>> fetchMatchingDocuments(
-    Query<Map<String, dynamic>> query,
-  ) async {
-    final snap = await query.get();
-    return [for (final doc in snap.docs) doc.data()];
-  }
-}
-
-class MockUserRepository extends Mock implements UserRepository {}
-
 class MockFirestore extends Mock implements Firestore {}
 
 class MockCollectionReference<T> extends Mock
@@ -124,128 +57,78 @@ class MockQueryDocumentSnapshot<T> extends Mock
 class MockWriteResult extends Mock implements WriteResult {}
 
 void main() {
-  group('UserService', () {
-    late MockUserRepository mockRepo;
-    late UserService service;
-
-    setUp(() {
-      mockRepo = MockUserRepository();
-      service = UserService(mockRepo);
-    });
-
-    test(
-      'getDisplayName returns the display name from the repository',
-      () async {
-        when(
-          () => mockRepo.findById('user-1'),
-        ).thenAnswer((_) async => {'displayName': 'Alice'});
-
-        expect(await service.getDisplayName('user-1'), 'Alice');
-        verify(() => mockRepo.findById('user-1')).called(1);
-      },
-    );
-
-    test('getDisplayName returns null when the user does not exist', () async {
-      when(() => mockRepo.findById('missing')).thenAnswer((_) async => null);
-
-      expect(await service.getDisplayName('missing'), isNull);
-    });
-
-    test(
-      'createUser delegates to the repository with the correct data',
-      () async {
-        when(
-          () => mockRepo.save('user-2', {'displayName': 'Bob'}),
-        ).thenAnswer((_) async {});
-
-        await service.createUser('user-2', 'Bob');
-
-        verify(() => mockRepo.save('user-2', {'displayName': 'Bob'})).called(1);
-      },
-    );
-
-    test(
-      'countUsers returns the number of users from the repository',
-      () async {
-        when(mockRepo.findAll).thenAnswer(
-          (_) async => [
-            {'displayName': 'Alice'},
-            {'displayName': 'Bob'},
-          ],
-        );
-
-        expect(await service.countUsers(), 2);
-      },
-    );
-  });
-
-  group('FirestoreUserRepository', () {
+  group('Firestore', () {
     late MockFirestore mockFirestore;
     late MockCollectionReference<Map<String, dynamic>> mockCollection;
     late MockDocumentReference<Map<String, dynamic>> mockDoc;
-    late FirestoreUserRepository repo;
 
     setUp(() {
       mockFirestore = MockFirestore();
       mockCollection = MockCollectionReference();
       mockDoc = MockDocumentReference();
-      repo = FirestoreUserRepository(mockFirestore);
 
       when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
       when(() => mockCollection.doc(any())).thenReturn(mockDoc);
     });
 
-    test('findById returns data when document exists', () async {
-      final mockSnap = MockDocumentSnapshot<Map<String, dynamic>>();
-      when(mockDoc.get).thenAnswer((_) async => mockSnap);
-      when(mockSnap.data).thenReturn({'displayName': 'Alice'});
-
-      expect(await repo.findById('user-1'), {'displayName': 'Alice'});
-      verify(() => mockFirestore.collection('users')).called(1);
-      verify(() => mockCollection.doc('user-1')).called(1);
+    test('collection returns the expected collection', () {
+      expect(
+        mockFirestore.collection('users'),
+        isA<CollectionReference<Map<String, dynamic>>>(),
+      );
     });
 
-    test('save calls set on the document reference', () async {
+    test('get returns the document data', () async {
+      final mockSnap = MockDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.get).thenAnswer((_) async => mockSnap);
+      when(mockSnap.data).thenReturn({'name': 'Alice'});
+
+      final snap = await mockFirestore.collection('users').doc('u1').get();
+
+      expect(snap.data(), {'name': 'Alice'});
+    });
+
+    test('set writes the document data', () async {
       when(
-        () => mockDoc.set({'displayName': 'Bob'}),
+        () => mockDoc.set({'name': 'Bob'}),
       ).thenAnswer((_) async => MockWriteResult());
 
-      await repo.save('user-2', {'displayName': 'Bob'});
+      await mockFirestore.collection('users').doc('u2').set({'name': 'Bob'});
 
-      verify(() => mockDoc.set({'displayName': 'Bob'})).called(1);
+      verify(() => mockDoc.set({'name': 'Bob'})).called(1);
     });
   });
 
-  group('ReportService', () {
+  group('Query', () {
     late MockQuery<Map<String, dynamic>> mockQuery;
     late MockQuerySnapshot<Map<String, dynamic>> mockSnapshot;
-    late ReportService service;
 
     setUp(() {
       mockQuery = MockQuery();
       mockSnapshot = MockQuerySnapshot();
-      service = ReportService();
-
       when(mockQuery.get).thenAnswer((_) async => mockSnapshot);
     });
 
-    test('countMatchingDocuments returns the snapshot size', () async {
-      when(() => mockSnapshot.size).thenReturn(5);
-
-      expect(await service.countMatchingDocuments(mockQuery), 5);
-      verify(mockQuery.get).called(1);
+    test('get returns the query results', () async {
+      expect(await mockQuery.get(), isA<QuerySnapshot<Map<String, dynamic>>>());
     });
 
-    test('fetchMatchingDocuments returns mapped document data', () async {
+    test('snapshot returns the correct size', () async {
+      when(() => mockSnapshot.size).thenReturn(3);
+
+      expect((await mockQuery.get()).size, 3);
+    });
+
+    test('snapshot returns the correct documents', () async {
       final doc1 = MockQueryDocumentSnapshot<Map<String, dynamic>>();
       final doc2 = MockQueryDocumentSnapshot<Map<String, dynamic>>();
       when(doc1.data).thenReturn({'name': 'Alice'});
       when(doc2.data).thenReturn({'name': 'Bob'});
       when(() => mockSnapshot.docs).thenReturn([doc1, doc2]);
 
-      final result = await service.fetchMatchingDocuments(mockQuery);
+      final docs = (await mockQuery.get()).docs;
 
-      expect(result, [
+      expect(docs.map((d) => d.data()).toList(), [
         {'name': 'Alice'},
         {'name': 'Bob'},
       ]);

--- a/packages/firebase_admin_sdk/example/test/examples_test.dart
+++ b/packages/firebase_admin_sdk/example/test/examples_test.dart
@@ -86,11 +86,33 @@ class MockUserRepository extends Mock implements UserRepository {}
 class MockFirestore extends Mock implements Firestore {}
 
 class MockCollectionReference<T> extends Mock
-    implements CollectionReference<T> {}
+    implements CollectionReference<T> {
+  @override
+  CollectionReference<U> withConverter<U>({
+    Object? fromFirestore,
+    Object? toFirestore,
+  }) => throw UnimplementedError();
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+
+  @override
+  int get hashCode => identityHashCode(this);
+}
 
 class MockDocumentReference<T> extends Mock implements DocumentReference<T> {}
 
-class MockQuery<T> extends Mock implements Query<T> {}
+class MockQuery<T> extends Mock implements Query<T> {
+  @override
+  Query<U> withConverter<U>({Object? fromFirestore, Object? toFirestore}) =>
+      throw UnimplementedError();
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+
+  @override
+  int get hashCode => identityHashCode(this);
+}
 
 class MockQuerySnapshot<T> extends Mock implements QuerySnapshot<T> {}
 

--- a/packages/firebase_admin_sdk/example/test/examples_test.dart
+++ b/packages/firebase_admin_sdk/example/test/examples_test.dart
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+abstract interface class UserRepository {
+  Future<Map<String, dynamic>?> findById(String id);
+
+  Future<void> save(String id, Map<String, dynamic> data);
+
+  Future<List<Map<String, dynamic>>> findAll();
+}
+
+class FirestoreUserRepository implements UserRepository {
+  FirestoreUserRepository(this._firestore);
+
+  final Firestore _firestore;
+
+  @override
+  Future<Map<String, dynamic>?> findById(String id) async {
+    final snap = await _firestore.collection('users').doc(id).get();
+    return snap.data();
+  }
+
+  @override
+  Future<void> save(String id, Map<String, dynamic> data) {
+    return _firestore.collection('users').doc(id).set(data);
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> findAll() async {
+    final snap = await _firestore.collection('users').get();
+    return [for (final doc in snap.docs) doc.data()];
+  }
+}
+
+class UserService {
+  UserService(this._repo);
+
+  final UserRepository _repo;
+
+  Future<String?> getDisplayName(String id) async {
+    final data = await _repo.findById(id);
+    return data?['displayName'] as String?;
+  }
+
+  Future<void> createUser(String id, String displayName) {
+    return _repo.save(id, {'displayName': displayName});
+  }
+
+  Future<int> countUsers() async {
+    final users = await _repo.findAll();
+    return users.length;
+  }
+}
+
+class ReportService {
+  Future<int> countMatchingDocuments(Query<Map<String, dynamic>> query) async {
+    final snap = await query.get();
+    return snap.size;
+  }
+
+  Future<List<Map<String, dynamic>>> fetchMatchingDocuments(
+    Query<Map<String, dynamic>> query,
+  ) async {
+    final snap = await query.get();
+    return [for (final doc in snap.docs) doc.data()];
+  }
+}
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+class MockFirestore extends Mock implements Firestore {}
+
+class MockCollectionReference<T> extends Mock
+    implements CollectionReference<T> {}
+
+class MockDocumentReference<T> extends Mock implements DocumentReference<T> {}
+
+class MockQuery<T> extends Mock implements Query<T> {}
+
+class MockQuerySnapshot<T> extends Mock implements QuerySnapshot<T> {}
+
+class MockDocumentSnapshot<T> extends Mock implements DocumentSnapshot<T> {}
+
+class MockQueryDocumentSnapshot<T> extends Mock
+    implements QueryDocumentSnapshot<T> {}
+
+class MockWriteResult extends Mock implements WriteResult {}
+
+void main() {
+  group('UserService', () {
+    late MockUserRepository mockRepo;
+    late UserService service;
+
+    setUp(() {
+      mockRepo = MockUserRepository();
+      service = UserService(mockRepo);
+    });
+
+    test(
+      'getDisplayName returns the display name from the repository',
+      () async {
+        when(
+          () => mockRepo.findById('user-1'),
+        ).thenAnswer((_) async => {'displayName': 'Alice'});
+
+        expect(await service.getDisplayName('user-1'), 'Alice');
+        verify(() => mockRepo.findById('user-1')).called(1);
+      },
+    );
+
+    test('getDisplayName returns null when the user does not exist', () async {
+      when(() => mockRepo.findById('missing')).thenAnswer((_) async => null);
+
+      expect(await service.getDisplayName('missing'), isNull);
+    });
+
+    test(
+      'createUser delegates to the repository with the correct data',
+      () async {
+        when(
+          () => mockRepo.save('user-2', {'displayName': 'Bob'}),
+        ).thenAnswer((_) async {});
+
+        await service.createUser('user-2', 'Bob');
+
+        verify(() => mockRepo.save('user-2', {'displayName': 'Bob'})).called(1);
+      },
+    );
+
+    test(
+      'countUsers returns the number of users from the repository',
+      () async {
+        when(mockRepo.findAll).thenAnswer(
+          (_) async => [
+            {'displayName': 'Alice'},
+            {'displayName': 'Bob'},
+          ],
+        );
+
+        expect(await service.countUsers(), 2);
+      },
+    );
+  });
+
+  group('FirestoreUserRepository', () {
+    late MockFirestore mockFirestore;
+    late MockCollectionReference<Map<String, dynamic>> mockCollection;
+    late MockDocumentReference<Map<String, dynamic>> mockDoc;
+    late FirestoreUserRepository repo;
+
+    setUp(() {
+      mockFirestore = MockFirestore();
+      mockCollection = MockCollectionReference();
+      mockDoc = MockDocumentReference();
+      repo = FirestoreUserRepository(mockFirestore);
+
+      when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
+      when(() => mockCollection.doc(any())).thenReturn(mockDoc);
+    });
+
+    test('findById returns data when document exists', () async {
+      final mockSnap = MockDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.get).thenAnswer((_) async => mockSnap);
+      when(mockSnap.data).thenReturn({'displayName': 'Alice'});
+
+      expect(await repo.findById('user-1'), {'displayName': 'Alice'});
+      verify(() => mockFirestore.collection('users')).called(1);
+      verify(() => mockCollection.doc('user-1')).called(1);
+    });
+
+    test('save calls set on the document reference', () async {
+      when(
+        () => mockDoc.set({'displayName': 'Bob'}),
+      ).thenAnswer((_) async => MockWriteResult());
+
+      await repo.save('user-2', {'displayName': 'Bob'});
+
+      verify(() => mockDoc.set({'displayName': 'Bob'})).called(1);
+    });
+  });
+
+  group('ReportService', () {
+    late MockQuery<Map<String, dynamic>> mockQuery;
+    late MockQuerySnapshot<Map<String, dynamic>> mockSnapshot;
+    late ReportService service;
+
+    setUp(() {
+      mockQuery = MockQuery();
+      mockSnapshot = MockQuerySnapshot();
+      service = ReportService();
+
+      when(mockQuery.get).thenAnswer((_) async => mockSnapshot);
+    });
+
+    test('countMatchingDocuments returns the snapshot size', () async {
+      when(() => mockSnapshot.size).thenReturn(5);
+
+      expect(await service.countMatchingDocuments(mockQuery), 5);
+      verify(mockQuery.get).called(1);
+    });
+
+    test('fetchMatchingDocuments returns mapped document data', () async {
+      final doc1 = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final doc2 = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      when(doc1.data).thenReturn({'name': 'Alice'});
+      when(doc2.data).thenReturn({'name': 'Bob'});
+      when(() => mockSnapshot.docs).thenReturn([doc1, doc2]);
+
+      final result = await service.fetchMatchingDocuments(mockQuery);
+
+      expect(result, [
+        {'name': 'Alice'},
+        {'name': 'Bob'},
+      ]);
+    });
+  });
+}

--- a/packages/google_cloud_firestore/lib/src/collection_group.dart
+++ b/packages/google_cloud_firestore/lib/src/collection_group.dart
@@ -15,7 +15,7 @@
 part of 'firestore.dart';
 
 @immutable
-final class CollectionGroup<T> extends Query<T> {
+interface class CollectionGroup<T> extends Query<T> {
   CollectionGroup._(
     String collectionId, {
     required super.firestore,

--- a/packages/google_cloud_firestore/lib/src/reference/collection_reference.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/collection_reference.dart
@@ -15,7 +15,7 @@
 part of '../firestore.dart';
 
 @immutable
-final class CollectionReference<T> extends Query<T> {
+interface class CollectionReference<T> extends Query<T> {
   CollectionReference._({
     required super.firestore,
     required _ResourcePath path,

--- a/packages/google_cloud_firestore/lib/src/reference/document_reference.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/document_reference.dart
@@ -15,7 +15,7 @@
 part of '../firestore.dart';
 
 @immutable
-final class DocumentReference<T> implements _Serializable {
+interface class DocumentReference<T> implements _Serializable {
   const DocumentReference._({
     required this.firestore,
     required _ResourcePath path,

--- a/packages/google_cloud_firestore/lib/src/reference/query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query.dart
@@ -15,7 +15,7 @@
 part of '../firestore.dart';
 
 @immutable
-base class Query<T> {
+interface class Query<T> {
   const Query._({
     required this.firestore,
     required _QueryOptions<T> queryOptions,
@@ -55,7 +55,6 @@ base class Query<T> {
   ///
   /// Passing `null` for both parameters removes the current converter and
   /// returns an untyped `Query<DocumentData>`.
-  @mustBeOverridden
   Query<U> withConverter<U>({
     FromFirestore<U>? fromFirestore,
     ToFirestore<U>? toFirestore,
@@ -994,7 +993,6 @@ base class Query<T> {
     return Query<T>._(firestore: firestore, queryOptions: options);
   }
 
-  @mustBeOverridden
   @override
   bool operator ==(Object other) {
     return other is Query<T> &&

--- a/packages/google_cloud_firestore/lib/src/reference/query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query.dart
@@ -55,6 +55,7 @@ interface class Query<T> {
   ///
   /// Passing `null` for both parameters removes the current converter and
   /// returns an untyped `Query<DocumentData>`.
+  @mustBeOverridden
   Query<U> withConverter<U>({
     FromFirestore<U>? fromFirestore,
     ToFirestore<U>? toFirestore,
@@ -993,6 +994,7 @@ interface class Query<T> {
     return Query<T>._(firestore: firestore, queryOptions: options);
   }
 
+  @mustBeOverridden
   @override
   bool operator ==(Object other) {
     return other is Query<T> &&

--- a/packages/google_cloud_firestore/lib/src/serializer.dart
+++ b/packages/google_cloud_firestore/lib/src/serializer.dart
@@ -36,7 +36,7 @@ const kNegInfinitySentinel = '__fs_double_neg_infinity__';
 @internal
 const kNaNSentinel = '__fs_double_nan__';
 
-abstract base class _Serializable {
+abstract class _Serializable {
   firestore_v1.Value _toProto();
 }
 


### PR DESCRIPTION
`Query`, `CollectionReference`, `DocumentReference`, and `CollectionGroup` were `final`/`base` classes, which prevented consumers from using `package:mocktail` or `package:mockito` to unit test code that depends on Firestore.

Added `test/examples_test.dart` to the example package demonstrating mocking of `Firestore`, `CollectionReference`, `DocumentReference`, and `Query`.

Closes #94 