### PR TITLE
feat(app): make FirebaseApp.client public, added AppOptions.additionalScopes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Download addlicense
         run: |
@@ -118,7 +118,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -172,7 +172,7 @@ jobs:
 
       - name: Comment coverage on PR
         if: matrix.dart-version == 'stable' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const coverage = '${{ steps.coverage.outputs.coverage }}';
@@ -225,7 +225,7 @@ jobs:
       - name: Upload coverage to codecov
         if: matrix.dart-version == 'stable'
         continue-on-error: true
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v4
         with:
           files: coverage.lcov
           flags: unittests
@@ -259,7 +259,7 @@ jobs:
           sdk: ${{ matrix.dart-version }}
 
       - name: Authenticate to Google Cloud/Firebase
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ secrets.SERVICE_ACCOUNT }}'

--- a/packages/firebase_admin_sdk/CHANGELOG.md
+++ b/packages/firebase_admin_sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Remove dependency on `package:equatable`.
 - Make `Query`, `CollectionReference`, `DocumentReference`, and `CollectionGroup` mockable.
+- `Credential.createClient(List<String> scopes)` — create an authenticated `AuthClient` directly 
+from a credential with custom scopes, without needing a `FirebaseApp` instance.
+- AppOptions.additionalScopes` — append extra OAuth2 scopes to the SDK-managed HTTP client 
+without providing your own `AuthClient`.
+- `FirebaseApp.client` is now part of the public API.
 
 ## 0.5.1
 

--- a/packages/firebase_admin_sdk/lib/src/app/app_options.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/app_options.dart
@@ -27,6 +27,7 @@ class AppOptions {
     this.serviceAccountId,
     this.httpClient,
     this.databaseAuthVariableOverride,
+    this.additionalScopes = const [],
   });
 
   /// A credential used to authenticate the Admin SDK.
@@ -98,6 +99,25 @@ class AppOptions {
   /// );
   /// ```
   final googleapis_auth.AuthClient? httpClient;
+
+  /// Additional OAuth2 scopes to request when creating the authenticated HTTP client.
+  ///
+  /// The SDK always requests the scopes it needs internally
+  /// (`cloud-platform` and `firebase`). Use this when you also need access to
+  /// Google APIs not covered by those scopes.
+  ///
+  /// Has no effect when [httpClient] is provided — the SDK uses that client
+  /// as-is and does not request any scopes on your behalf.
+  ///
+  /// Example — add a BigQuery scope so [FirebaseApp.client] can be used with
+  /// the BigQuery API:
+  /// ```dart
+  /// AppOptions(
+  ///   credential: Credential.fromServiceAccount(File('sa.json')),
+  ///   additionalScopes: ['https://www.googleapis.com/auth/bigquery'],
+  /// )
+  /// ```
+  final List<String> additionalScopes;
 
   /// The object to use as the auth variable in Realtime Database Rules.
   ///

--- a/packages/firebase_admin_sdk/lib/src/app/app_options.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/app_options.dart
@@ -163,6 +163,10 @@ class AppOptions {
           databaseURL == other.databaseURL &&
           storageBucket == other.storageBucket &&
           serviceAccountId == other.serviceAccountId &&
+          const ListEquality<String>().equals(
+            additionalScopes,
+            other.additionalScopes,
+          ) &&
           const MapEquality<String, dynamic>().equals(
             databaseAuthVariableOverride,
             other.databaseAuthVariableOverride,
@@ -174,6 +178,7 @@ class AppOptions {
     databaseURL,
     storageBucket,
     serviceAccountId,
+    const ListEquality<String>().hash(additionalScopes),
     const MapEquality<String, dynamic>().hash(databaseAuthVariableOverride),
   );
 }

--- a/packages/firebase_admin_sdk/lib/src/app/credential.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/credential.dart
@@ -240,6 +240,29 @@ sealed class Credential {
   /// Private constructor for sealed class.
   Credential._();
 
+  /// Creates an authenticated HTTP client scoped to [scopes].
+  ///
+  /// Use this when you need to call Google APIs directly — for example,
+  /// passing the client to a `googleapis` API that is not covered by this SDK.
+  ///
+  /// The returned client handles token refresh automatically. You are
+  /// responsible for closing the client when you no longer need it.
+  ///
+  /// Example — use the authenticated client with the `googleapis` Storage API:
+  /// ```dart
+  /// final client = await credential.createClient([
+  ///   'https://www.googleapis.com/auth/cloud-platform',
+  ///   'https://www.googleapis.com/auth/devstorage.full_control',
+  /// ]);
+  /// try {
+  ///   final storage = StorageApi(client);
+  ///   // ...
+  /// } finally {
+  ///   client.close();
+  /// }
+  /// ```
+  Future<googleapis_auth.AuthClient> createClient(List<String> scopes);
+
   /// Returns the underlying [googleapis_auth.ServiceAccountCredentials] if this is a
   /// [ServiceAccountCredential], null otherwise.
   @internal
@@ -285,6 +308,13 @@ final class ServiceAccountCredential extends Credential {
   String get privateKey => _serviceAccountCredentials.privateKey;
 
   @override
+  Future<googleapis_auth.AuthClient> createClient(List<String> scopes) =>
+      googleapis_auth.clientViaServiceAccount(
+        _serviceAccountCredentials,
+        scopes,
+      );
+
+  @override
   googleapis_auth.ServiceAccountCredentials? get serviceAccountCredentials =>
       _serviceAccountCredentials;
 
@@ -312,6 +342,14 @@ final class RefreshTokenCredential extends Credential {
 
   /// The OAuth2 refresh token.
   final String refreshToken;
+
+  @override
+  Future<googleapis_auth.AuthClient> createClient(List<String> scopes) =>
+      googleapis_auth.clientViaRefreshToken(
+        googleapis_auth.ClientId(clientId, clientSecret),
+        refreshToken,
+        scopes,
+      );
 
   @override
   googleapis_auth.ServiceAccountCredentials? get serviceAccountCredentials =>
@@ -343,6 +381,10 @@ final class ApplicationDefaultCredential extends Credential {
       super._();
 
   final String? _serviceAccountId;
+
+  @override
+  Future<googleapis_auth.AuthClient> createClient(List<String> scopes) =>
+      googleapis_auth.clientViaApplicationDefaultCredentials(scopes: scopes);
 
   @override
   googleapis_auth.ServiceAccountCredentials? get serviceAccountCredentials =>

--- a/packages/firebase_admin_sdk/lib/src/app/firebase_app.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/firebase_app.dart
@@ -107,47 +107,42 @@ class FirebaseApp {
   Future<googleapis_auth.AuthClient>? _httpClient;
 
   Future<googleapis_auth.AuthClient> _createDefaultClient() async {
-    // Always create an authenticated client for production services.
-    // Services with emulators (Firestore, Auth) create their own
-    // unauthenticated clients when in emulator mode to avoid ADC warnings.
-
-    // Use proper OAuth scope constants
     final scopes = [
       auth3.IdentityToolkitApi.cloudPlatformScope,
       auth3.IdentityToolkitApi.firebaseScope,
+      ...options.additionalScopes,
     ];
-
-    // Get credential
-    final credential = options.credential;
-
-    // Create authenticated client based on credential type
-    final client = switch (credential) {
-      Credential(:final serviceAccountCredentials?) =>
-        googleapis_auth.clientViaServiceAccount(
-          serviceAccountCredentials,
-          scopes,
-        ),
-      RefreshTokenCredential(
-        :final clientId,
-        :final clientSecret,
-        :final refreshToken,
-      ) =>
-        googleapis_auth.clientViaRefreshToken(
-          googleapis_auth.ClientId(clientId, clientSecret),
-          refreshToken,
-          scopes,
-        ),
-      _ => googleapis_auth.clientViaApplicationDefaultCredentials(
-        scopes: scopes,
-      ),
-    };
-
-    return FirebaseUserAgentClient(await client);
+    final credential =
+        options.credential ?? Credential.fromApplicationDefaultCredentials();
+    return FirebaseUserAgentClient(await credential.createClient(scopes));
   }
 
-  /// Returns the HTTP client for this app.
-  /// Lazily initializes on first access.
-  @internal
+  /// The authenticated HTTP client for this app.
+  ///
+  /// Lazily initialized on first access. Returns the client provided via
+  /// [AppOptions.httpClient] if one was supplied, otherwise creates a default
+  /// client using the app's [AppOptions.credential] and the SDK's required
+  /// scopes plus any [AppOptions.additionalScopes].
+  ///
+  /// Use this when you need to call Google APIs not directly supported by this
+  /// SDK — for example, passing the client to a `googleapis` package API for
+  /// advanced Cloud Storage operations (resumable uploads, byte-range fetches,
+  /// etc.).
+  ///
+  /// **Lifecycle:** The client is closed automatically when [close] is called,
+  /// unless it was provided via [AppOptions.httpClient] — in that case you own
+  /// its lifecycle and must close it yourself.
+  ///
+  /// **Scopes:** The default client is granted `cloud-platform` and `firebase`
+  /// scopes, which cover most Google APIs. If you need additional scopes,
+  /// set [AppOptions.additionalScopes] — or provide a fully configured client
+  /// via [AppOptions.httpClient].
+  ///
+  /// Example:
+  /// ```dart
+  /// final storageApi = StorageApi(await app.client);
+  /// final object = await storageApi.objects.get(bucket, objectName);
+  /// ```
   Future<googleapis_auth.AuthClient> get client {
     return _httpClient ??= options.httpClient != null
         ? Future.value(options.httpClient!)

--- a/packages/firebase_admin_sdk/test/integration/app_check/app_check_test.dart
+++ b/packages/firebase_admin_sdk/test/integration/app_check/app_check_test.dart
@@ -20,7 +20,7 @@ import 'package:test/test.dart';
 
 import '../../fixtures/helpers.dart';
 
-const _testAppId = '1:559949546715:android:13025aec6cc3243d0ab8fe';
+const _testAppId = '1:559949546715:android:4268b2eabcd3124b0ab8fe';
 
 void main() {
   group(


### PR DESCRIPTION
Closes #208.

`FirebaseApp.client` was `@internal`, forcing users who need an authenticated HTTP client (e.g. for advanced `googleapis` APIs not covered by this SDK) to either silence the warning and use the internal API, or re-implement the entire credential-initialization logic themselves.

## Changes

### `FirebaseApp.client` — now public

Allows users to reuse the app's already-managed authenticated client for `googleapis` APIs, rather than spinning up a second client with a separate token lifecycle:

```dart
// Option A — reuse the app's managed client (same token refresh, same lifecycle)
final storageApi = StorageApi(await app.client);
final media = await storageApi.objects.get(
  bucket,
  objectName,
  downloadOptions: DownloadOptions.fullMedia,
);

// Option B — standalone client from a credential
final client = await Credential.fromApplicationDefaultCredentials()
    .createClient(['https://www.googleapis.com/auth/cloud-platform']);
```

`Credential.createClient()` and `FirebaseApp.client` are complementary: `createClient()` gives full scope control and separate lifecycle ownership; `client` shares the app's managed client.

### `AppOptions.additionalScopes` — new field

The SDK's default client always requests `cloud-platform` and `firebase` scopes. `additionalScopes` lets callers append extra scopes without having to manage their own client:

```dart
final app = FirebaseApp.initializeApp(
  options: AppOptions(
    credential: Credential.fromServiceAccount(File('sa.json')),
    additionalScopes: [
      'https://www.googleapis.com/auth/devstorage.full_control',
    ],
  ),
);
```