### PR TITLE
fix(firestore): resolve project ID from env vars for authorized_user ADC credentials, updated README

### DIFF
--- a/packages/firebase_admin_sdk/example/bin/run_with_prod.dart
+++ b/packages/firebase_admin_sdk/example/bin/run_with_prod.dart
@@ -25,7 +25,14 @@
 //
 // Option 2: Application Default Credentials (alternative)
 //   1. Run: gcloud auth application-default login
-//   2. The SDK will automatically find these credentials if GOOGLE_APPLICATION_CREDENTIALS is not set.
+//   2. Set GOOGLE_CLOUD_PROJECT in your environment:
+//        export GOOGLE_CLOUD_PROJECT=your-project-id
+//   3. In main() below, remove the GOOGLE_APPLICATION_CREDENTIALS entry from
+//      the environment map (or set it to point at your ADC credentials file).
+//
+//   Note: credentials produced by `gcloud auth application-default login`
+//   (type: "authorized_user") do not contain a project_id field, so
+//   GOOGLE_CLOUD_PROJECT (or GCLOUD_PROJECT) must be set explicitly.
 //
 // For available environment variables, see:
 // packages/firebase_admin_sdk/lib/src/app/environment.dart
@@ -38,6 +45,11 @@ Future<void> main() async {
   final process = await Process.start(
     Platform.resolvedExecutable,
     ['run', 'bin/example.dart'],
+    // Option 1 (default): service account key file.
+    // Option 2 (gcloud auth): replace with {'GOOGLE_CLOUD_PROJECT': 'your-project-id'}.
+    // Note: `gcloud auth application-default login` credentials (type: "authorized_user")
+    // do not include a project_id, so the project must be supplied either via
+    // GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT or by passing projectId to AppOptions.
     environment: {'GOOGLE_APPLICATION_CREDENTIALS': 'service-account-key.json'},
     mode: ProcessStartMode.inheritStdio,
   );

--- a/packages/google_cloud_firestore/CHANGELOG.md
+++ b/packages/google_cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2-wip
+
+- Fixed `Firestore.projectId` not reading `GOOGLE_CLOUD_PROJECT` when using Application Default Credentials locally.
+
 ## 0.5.1
 
 - Added retry support for `WriteBatch.commit()` on transient errors (`ABORTED`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`).

--- a/packages/google_cloud_firestore/README.md
+++ b/packages/google_cloud_firestore/README.md
@@ -80,6 +80,7 @@ import 'package:google_cloud_firestore/google_cloud_firestore.dart';
 
 // Option 1: Use Application Default Credentials (ADC)
 // Recommended for Google environments like Cloud Run, App Engine, etc.
+// The project ID is discovered automatically from the environment.
 final firestore = Firestore();
 
 // Option 2: With a service account file
@@ -101,6 +102,23 @@ final firestoreWithParams = Firestore(
       projectId: 'my-project',
     ),
   ),
+);
+```
+
+#### Using ADC locally with gcloud auth
+
+When authenticating locally via `gcloud auth application-default login`, the
+credentials produced (type: `authorized_user`) do not include a project ID.
+You must supply it either via an environment variable or in `Settings`:
+
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project-id
+```
+
+```dart
+// Or set it explicitly in Settings
+final firestore = Firestore(
+  settings: Settings(projectId: 'your-project-id'),
 );
 ```
 

--- a/packages/google_cloud_firestore/example/main.dart
+++ b/packages/google_cloud_firestore/example/main.dart
@@ -18,6 +18,10 @@ void main() async {
   // By default, the `Firestore` class will use the currently configured project
   // and automatically attempt to authenticate using Application Default
   // Credentials.
+  //
+  // When running locally with `gcloud auth application-default login`, the
+  // project ID is not included in the credentials. Set the GOOGLE_CLOUD_PROJECT
+  // environment variable or pass it via Settings(projectId: 'your-project-id').
   final firestore = Firestore();
 
   final users = firestore.collection('users');

--- a/packages/google_cloud_firestore/lib/src/environment.dart
+++ b/packages/google_cloud_firestore/lib/src/environment.dart
@@ -39,7 +39,7 @@ abstract class Environment {
   ///
   /// Priority order:
   /// 1. Zone.current[envSymbol] (for package tests using runZoned)
-  /// 2. [environmentOverride] parameter (for client code tests)
+  /// 2. [environmentOverride] parameter (for cross-package tests)
   /// 3. Platform.environment (actual system environment)
   ///
   /// Example:
@@ -58,8 +58,7 @@ abstract class Environment {
       return zoneEnv[firestoreEmulatorHost];
     }
 
-    // Then check environmentOverride (for client code)
-    // This allows tests to explicitly remove environment variables
+    // Then check environmentOverride (for cross-package tests)
     if (environmentOverride != null) {
       return environmentOverride[firestoreEmulatorHost];
     }
@@ -71,11 +70,6 @@ abstract class Environment {
   /// Checks if the Firestore emulator is enabled via environment variable.
   ///
   /// Returns `true` if [firestoreEmulatorHost] is set in the environment.
-  ///
-  /// Priority order (same as [getFirestoreEmulatorHost]):
-  /// 1. Zone.current[envSymbol] (for package tests using runZoned)
-  /// 2. [environmentOverride] parameter (for client code tests)
-  /// 3. Platform.environment (actual system environment)
   ///
   /// Example:
   /// ```dart

--- a/packages/google_cloud_firestore/lib/src/firestore.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore.dart
@@ -341,6 +341,12 @@ class Firestore {
     final explicit = _settings.projectId;
     if (explicit != null) return explicit;
 
+    // Check environment variables and credentials file synchronously.
+    // Async strategies (gcloud CLI, metadata server) are handled by _run()
+    // and cached in cachedProjectId after the first API call.
+    final discovered = _firestoreClient.getProjectId();
+    if (discovered != null) return discovered;
+
     throw StateError(
       'Project ID has not been discovered yet. '
       'Initialize the SDK with credentials that include a project ID, '

--- a/packages/google_cloud_firestore/lib/src/firestore.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore.dart
@@ -170,8 +170,10 @@ class Settings {
 
   /// Environment variable overrides for testing.
   ///
-  /// This allows tests to inject environment variables (like FIRESTORE_EMULATOR_HOST)
-  /// without modifying the actual process environment.
+  /// Allows cross-package tests to inject environment variables (such as
+  /// `FIRESTORE_EMULATOR_HOST`) without modifying the actual process
+  /// environment. Within `google_cloud_firestore` itself, prefer using
+  /// `runZoned` with `envSymbol` instead.
   ///
   /// Example:
   /// ```dart

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -179,10 +179,10 @@ class FirestoreHttpClient {
   /// Returns `null` when only async strategies (gcloud CLI, metadata server)
   /// could succeed; those are handled by [_run] and cached in [cachedProjectId].
   String? getProjectId() {
-    final env = _settings.environmentOverride;
-    if (env != null) {
+    final zoneEnv = Zone.current[envSymbol] as Map<String, String>?;
+    if (zoneEnv != null) {
       for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
-        final value = env[envKey];
+        final value = zoneEnv[envKey];
         if (value != null) return value;
       }
       return null;
@@ -249,10 +249,10 @@ class FirestoreHttpClient {
 
     String? projectId;
 
-    final env = _settings.environmentOverride;
-    if (env != null) {
+    final zoneEnv = Zone.current[envSymbol] as Map<String, String>?;
+    if (zoneEnv != null) {
       for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
-        final value = env[envKey];
+        final value = zoneEnv[envKey];
         if (value != null) {
           projectId = value;
           break;

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -173,6 +173,28 @@ class FirestoreHttpClient {
 
   String? get cachedProjectId => _cachedProjectId;
 
+  /// Synchronously resolves the project ID from environment variables or the
+  /// credentials file, without any network I/O.
+  ///
+  /// Returns `null` when only async strategies (gcloud CLI, metadata server)
+  /// could succeed; those are handled by [_run] and cached in [cachedProjectId].
+  String? getProjectId() {
+    final env = _settings.environmentOverride;
+    if (env != null) {
+      for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
+        final value = env[envKey];
+        if (value != null) return value;
+      }
+      return null;
+    }
+
+    final explicitProjectId = _settings.projectId;
+    if (explicitProjectId != null) return explicitProjectId;
+
+    return google_cloud.projectIdFromEnvironmentVariables() ??
+        google_cloud.projectIdFromCredentialsFile();
+  }
+
   /// Gets the Firestore API host URL based on emulator configuration.
   Uri get _firestoreApiHost {
     final emulatorHost = Environment.getFirestoreEmulatorHost(

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -176,23 +176,44 @@ class FirestoreHttpClient {
   /// Synchronously resolves the project ID from environment variables or the
   /// credentials file, without any network I/O.
   ///
+  /// Checks (in order): [cachedProjectId], Zone env ([envSymbol]),
+  /// [Settings.environmentOverride], real environment variables, then the
+  /// credentials file at `GOOGLE_APPLICATION_CREDENTIALS`.
+  ///
   /// Returns `null` when only async strategies (gcloud CLI, metadata server)
   /// could succeed; those are handled by [_run] and cached in [cachedProjectId].
   String? getProjectId() {
+    if (_cachedProjectId != null) return _cachedProjectId;
+
     final zoneEnv = Zone.current[envSymbol] as Map<String, String>?;
+    String? discovered;
+
     if (zoneEnv != null) {
       for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
         final value = zoneEnv[envKey];
-        if (value != null) return value;
+        if (value != null) {
+          discovered = value;
+          break;
+        }
       }
-      return null;
+    } else {
+      final envOverride = _settings.environmentOverride;
+      if (envOverride != null) {
+        for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
+          final value = envOverride[envKey];
+          if (value != null) {
+            discovered = value;
+            break;
+          }
+        }
+      } else {
+        discovered =
+            google_cloud.projectIdFromEnvironmentVariables() ??
+            google_cloud.projectIdFromCredentialsFile();
+      }
     }
 
-    final explicitProjectId = _settings.projectId;
-    if (explicitProjectId != null) return explicitProjectId;
-
-    return google_cloud.projectIdFromEnvironmentVariables() ??
-        google_cloud.projectIdFromCredentialsFile();
+    return discovered != null ? (_cachedProjectId = discovered) : null;
   }
 
   /// Gets the Firestore API host URL based on emulator configuration.
@@ -247,25 +268,14 @@ class FirestoreHttpClient {
   ) async {
     final client = await _client;
 
-    String? projectId;
-
-    final zoneEnv = Zone.current[envSymbol] as Map<String, String>?;
-    if (zoneEnv != null) {
-      for (final envKey in google_cloud.projectIdEnvironmentVariableOptions) {
-        final value = zoneEnv[envKey];
-        if (value != null) {
-          projectId = value;
-          break;
-        }
-      }
-    }
-
-    projectId ??= _settings.projectId;
-    projectId ??= await google_cloud.computeProjectId();
+    final projectId =
+        getProjectId() ??
+        _settings.projectId ??
+        await google_cloud.computeProjectId();
 
     _cachedProjectId = projectId;
 
-    return firestoreGuard(() => fn(client, projectId!));
+    return firestoreGuard(() => fn(client, projectId));
   }
 
   /// Executes a Firestore v1 API operation with automatic projectId injection.

--- a/packages/google_cloud_firestore/pubspec.yaml
+++ b/packages/google_cloud_firestore/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   database for mobile, web, and server development from Firebase and
   Google Cloud.
 resolution: workspace
-version: 0.5.1
+version: 0.5.2-wip
 repository: https://github.com/firebase/firebase-admin-dart/tree/main/packages/google_cloud_firestore
 
 environment:

--- a/packages/google_cloud_firestore/test/unit/firestore_test.dart
+++ b/packages/google_cloud_firestore/test/unit/firestore_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
 import 'package:google_cloud_firestore/src/firestore_http_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -46,6 +48,40 @@ void main() {
       );
 
       expect(firestore.projectId, 'explicit-project');
+    });
+
+    test(
+      'projectId getter returns value from GOOGLE_CLOUD_PROJECT env var',
+      () {
+        runZoned(
+          () {
+            final firestore = Firestore(settings: const Settings());
+            expect(firestore.projectId, 'env-project');
+          },
+          zoneValues: {
+            envSymbol: <String, String>{'GOOGLE_CLOUD_PROJECT': 'env-project'},
+          },
+        );
+      },
+    );
+
+    test('projectId getter returns value from GCLOUD_PROJECT env var', () {
+      runZoned(
+        () {
+          final firestore = Firestore(settings: const Settings());
+          expect(firestore.projectId, 'env-project');
+        },
+        zoneValues: {
+          envSymbol: <String, String>{'GCLOUD_PROJECT': 'env-project'},
+        },
+      );
+    });
+
+    test('projectId getter throws when no project ID is discoverable', () {
+      runZoned(() {
+        final firestore = Firestore(settings: const Settings());
+        expect(() => firestore.projectId, throwsStateError);
+      }, zoneValues: {envSymbol: <String, String>{}});
     });
 
     test('databaseId getter returns default when not set', () {

--- a/packages/google_cloud_firestore/test/unit/write_batch_test.dart
+++ b/packages/google_cloud_firestore/test/unit/write_batch_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -382,6 +383,7 @@ void main() {
     late Firestore firestore;
     late int callCount;
     late void Function(HttpRequest request, int callNumber) handler;
+    late Map<Object, Object?> zoneValues;
 
     setUp(() async {
       callCount = 0;
@@ -394,14 +396,14 @@ void main() {
         handler(request, callCount);
       });
 
+      zoneValues = {
+        envSymbol: <String, String>{
+          'FIRESTORE_EMULATOR_HOST': 'localhost:${server.port}',
+        },
+      };
+
       firestore = Firestore(
-        settings: Settings(
-          projectId: 'test-project',
-          environmentOverride: {
-            'FIRESTORE_EMULATOR_HOST': 'localhost:${server.port}',
-            'GOOGLE_CLOUD_PROJECT': 'test-project',
-          },
-        ),
+        settings: const Settings(projectId: 'test-project'),
       );
     });
 
@@ -419,7 +421,10 @@ void main() {
         }
       };
 
-      await firestore.doc('test/retry').set({'value': 1});
+      await runZoned(
+        () => firestore.doc('test/retry').set({'value': 1}),
+        zoneValues: zoneValues,
+      );
       expect(callCount, 2);
     });
 
@@ -432,7 +437,10 @@ void main() {
         }
       };
 
-      await firestore.doc('test/retry').set({'value': 1});
+      await runZoned(
+        () => firestore.doc('test/retry').set({'value': 1}),
+        zoneValues: zoneValues,
+      );
       expect(callCount, 2);
     });
 
@@ -445,7 +453,10 @@ void main() {
         }
       };
 
-      await firestore.doc('test/retry').set({'value': 1});
+      await runZoned(
+        () => firestore.doc('test/retry').set({'value': 1}),
+        zoneValues: zoneValues,
+      );
       expect(callCount, 4);
     });
 
@@ -459,15 +470,18 @@ void main() {
         );
       };
 
-      await expectLater(
-        () => firestore.doc('test/retry').set({'value': 1}),
-        throwsA(
-          isA<FirestoreException>().having(
-            (e) => e.errorCode,
-            'errorCode',
-            FirestoreClientErrorCode.permissionDenied,
+      await runZoned(
+        () => expectLater(
+          () => firestore.doc('test/retry').set({'value': 1}),
+          throwsA(
+            isA<FirestoreException>().having(
+              (e) => e.errorCode,
+              'errorCode',
+              FirestoreClientErrorCode.permissionDenied,
+            ),
           ),
         ),
+        zoneValues: zoneValues,
       );
       expect(callCount, 1);
     });
@@ -477,15 +491,18 @@ void main() {
         _writeRetryError(request, 400, 'INVALID_ARGUMENT', 'Invalid field');
       };
 
-      await expectLater(
-        () => firestore.doc('test/retry').set({'value': 1}),
-        throwsA(
-          isA<FirestoreException>().having(
-            (e) => e.errorCode,
-            'errorCode',
-            FirestoreClientErrorCode.invalidArgument,
+      await runZoned(
+        () => expectLater(
+          () => firestore.doc('test/retry').set({'value': 1}),
+          throwsA(
+            isA<FirestoreException>().having(
+              (e) => e.errorCode,
+              'errorCode',
+              FirestoreClientErrorCode.invalidArgument,
+            ),
           ),
         ),
+        zoneValues: zoneValues,
       );
       expect(callCount, 1);
     });


### PR DESCRIPTION
Fixed a bug where `Firestore.projectId` threw even when `GOOGLE_CLOUD_PROJECT` was set, because the getter never actually read the environment variable despite mentioning it in the error message.

No breaking API changes.

Closes #254 