### PR TITLE
fix: auto-discover credential from env when options.credential is null

### DIFF
--- a/packages/firebase_admin_sdk/lib/src/app/app_options.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/app_options.dart
@@ -154,6 +154,29 @@ class AppOptions {
   /// ```
   final Map<String, dynamic>? databaseAuthVariableOverride;
 
+  AppOptions copyWith({
+    Credential? credential,
+    String? projectId,
+    String? databaseURL,
+    String? storageBucket,
+    String? serviceAccountId,
+    googleapis_auth.AuthClient? httpClient,
+    List<String>? additionalScopes,
+    Map<String, dynamic>? databaseAuthVariableOverride,
+  }) {
+    return AppOptions(
+      credential: credential ?? this.credential,
+      projectId: projectId ?? this.projectId,
+      databaseURL: databaseURL ?? this.databaseURL,
+      storageBucket: storageBucket ?? this.storageBucket,
+      serviceAccountId: serviceAccountId ?? this.serviceAccountId,
+      httpClient: httpClient ?? this.httpClient,
+      additionalScopes: additionalScopes ?? this.additionalScopes,
+      databaseAuthVariableOverride:
+          databaseAuthVariableOverride ?? this.databaseAuthVariableOverride,
+    );
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/packages/firebase_admin_sdk/lib/src/app/app_registry.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/app_registry.dart
@@ -57,12 +57,19 @@ class AppRegistry {
     name ??= _defaultAppName;
     _validateAppName(name);
 
-    var wasInitializedFromEnv = false;
-    final effectiveOptions = options ?? fetchOptionsFromEnvironment();
-
-    if (options == null) {
-      wasInitializedFromEnv = true;
-    }
+    final (effectiveOptions, wasInitializedFromEnv) = switch (options) {
+      null => (fetchOptionsFromEnvironment(), true),
+      AppOptions(credential: null) => (
+        options.copyWith(
+          credential: _credentialFromEnv(
+            Zone.current[envSymbol] as Map<String, String>? ??
+                Platform.environment,
+          ),
+        ),
+        false,
+      ),
+      _ => (options, false),
+    };
 
     // App doesn't exist - create it
     if (!_apps.containsKey(name)) {

--- a/packages/google_cloud_firestore/lib/src/timestamp.dart
+++ b/packages/google_cloud_firestore/lib/src/timestamp.dart
@@ -136,22 +136,6 @@ final class Timestamp implements _Serializable {
     return Timestamp(seconds: proto.seconds, nanoseconds: proto.nanos);
   }
 
-  factory Timestamp._fromString(String timestampValue) {
-    final date = DateTime.parse(timestampValue);
-    var nanos = 0;
-
-    if (timestampValue.length > 20) {
-      final nanoString = timestampValue.substring(
-        20,
-        timestampValue.length - 1,
-      );
-      final trailingZeroes = 9 - nanoString.length;
-      nanos = int.parse(nanoString) * (math.pow(10, trailingZeroes).toInt());
-    }
-
-    return Timestamp(seconds: (date.millisecondsSinceEpoch / 1000).floor(), nanoseconds: nanos);
-  }
-
   static const _msToNanos = 1000000;
   static const _usToNanos = 1000;
 

--- a/packages/google_cloud_firestore/test/unit/bundle_test.dart
+++ b/packages/google_cloud_firestore/test/unit/bundle_test.dart
@@ -363,11 +363,11 @@ void main() {
       );
 
       expect(
-        elements[1]['documentMetadata']['name'],
+        (elements[1]['documentMetadata'] as Map<String, dynamic>)['name'],
         equals('$databaseRoot/documents/collectionId_A/doc1'),
       );
       expect(
-        elements[3]['documentMetadata']['name'],
+        (elements[3]['documentMetadata'] as Map<String, dynamic>)['name'],
         equals('$databaseRoot/documents/collectionId_B/doc1'),
       );
     });


### PR DESCRIPTION
AppRegistry already had credential auto-discovery via _credentialFromEnv, but it only ran when options was null entirely. When options was provided without a credential, the credential stayed null. This fix extends auto-discovery to also apply when options.credential is null. Also adds AppOptions.copyWith to support this cleanly.

Related to issue this issue in firebase-functions-dart repo https://github.com/firebase/firebase-functions-dart/issues/162