### PR TITLE
fix: make UrlKeyFetcher http.Client injectable for testability

### DIFF
--- a/packages/firebase_admin_sdk/lib/src/auth/token_verifier.dart
+++ b/packages/firebase_admin_sdk/lib/src/auth/token_verifier.dart
@@ -70,6 +70,7 @@ class FirebaseTokenVerifier {
     required this.issuer,
     required this.tokenInfo,
     required this.app,
+    http.Client? httpClient,
   }) : _shortNameArticle =
            RegExp(
              '[aeiou]',
@@ -79,6 +80,7 @@ class FirebaseTokenVerifier {
            : 'a',
        _signatureVerifier = PublicKeySignatureVerifier.withCertificateUrl(
          clientCertUrl,
+         httpClient: httpClient,
        );
 
   final FirebaseApp app;

--- a/packages/firebase_admin_sdk/lib/src/utils/jwt.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/jwt.dart
@@ -58,9 +58,11 @@ abstract class KeyFetcher {
 }
 
 class UrlKeyFetcher implements KeyFetcher {
-  UrlKeyFetcher(this.clientCert);
+  UrlKeyFetcher(this.clientCert, {http.Client? httpClient})
+    : _httpClient = httpClient ?? http.Client();
 
   final Uri clientCert;
+  final http.Client _httpClient;
 
   Map<String, JWTKey>? _publicKeys;
   late DateTime _publicKeysExpireAt;
@@ -68,7 +70,7 @@ class UrlKeyFetcher implements KeyFetcher {
   @override
   Future<Map<String, JWTKey>> fetchPublicKeys() async {
     if (_shouldRefresh()) return refresh();
-    return _publicKeys!;
+    return _publicKeys ?? await refresh();
   }
 
   bool _shouldRefresh() {
@@ -77,7 +79,7 @@ class UrlKeyFetcher implements KeyFetcher {
   }
 
   Future<Map<String, JWTKey>> refresh() async {
-    final response = await http.get(clientCert);
+    final response = await _httpClient.get(clientCert);
     final json = jsonDecode(response.body) as Map<String, Object?>;
     final error = json['error'];
     if (error != null) {
@@ -126,8 +128,7 @@ class JwksFetcher implements KeyFetcher {
   @override
   Future<Map<String, JWTKey>> fetchPublicKeys() async {
     if (_shouldRefresh) return refresh();
-
-    return _publicKeys!;
+    return _publicKeys ?? await refresh();
   }
 
   bool get _shouldRefresh {
@@ -171,8 +172,10 @@ class JwksFetcher implements KeyFetcher {
 class PublicKeySignatureVerifier implements SignatureVerifier {
   PublicKeySignatureVerifier(this.keyFetcher);
 
-  PublicKeySignatureVerifier.withCertificateUrl(Uri clientCert)
-    : this(UrlKeyFetcher(clientCert));
+  PublicKeySignatureVerifier.withCertificateUrl(
+    Uri clientCert, {
+    http.Client? httpClient,
+  }) : this(UrlKeyFetcher(clientCert, httpClient: httpClient));
 
   factory PublicKeySignatureVerifier.withJwksUrl(Uri jwksUrl) {
     return PublicKeySignatureVerifier(JwksFetcher(jwksUrl));

--- a/packages/firebase_admin_sdk/lib/src/utils/jwt.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/jwt.dart
@@ -59,10 +59,10 @@ abstract class KeyFetcher {
 
 class UrlKeyFetcher implements KeyFetcher {
   UrlKeyFetcher(this.clientCert, {http.Client? httpClient})
-    : _httpClient = httpClient ?? http.Client();
+    : _httpClient = httpClient;
 
   final Uri clientCert;
-  final http.Client _httpClient;
+  final http.Client? _httpClient;
 
   Map<String, JWTKey>? _publicKeys;
   late DateTime _publicKeysExpireAt;
@@ -79,7 +79,8 @@ class UrlKeyFetcher implements KeyFetcher {
   }
 
   Future<Map<String, JWTKey>> refresh() async {
-    final response = await _httpClient.get(clientCert);
+    final response =
+        await (_httpClient?.get(clientCert) ?? http.get(clientCert));
     final json = jsonDecode(response.body) as Map<String, Object?>;
     final error = json['error'];
     if (error != null) {


### PR DESCRIPTION
Makes the HTTP client used by `UrlKeyFetcher` injectable so that tests can intercept the Google public key certificate endpoint without making real network calls.

This is a prerequisite for the real token verification tests added in the `firebase_functions` SDK (firebase/firebase-functions-dart#91). Previously `UrlKeyFetcher` always used a freshly-created `http.Client`, making it impossible to intercept the certificate fetch in tests.