### PR TITLE
fix(firestore): use DocumentReference<Object?> in Transaction.delete and update

### DIFF
--- a/packages/google_cloud_firestore/lib/src/transaction.dart
+++ b/packages/google_cloud_firestore/lib/src/transaction.dart
@@ -256,7 +256,7 @@ class Transaction {
   /// A [Precondition] restricting this update.
   ///
   void update(
-    DocumentReference<dynamic> documentRef,
+    DocumentReference<Object?> documentRef,
     Map<Object?, Object?> data, {
     Precondition? precondition,
   }) {
@@ -277,7 +277,7 @@ class Transaction {
   /// A delete for a non-existing document is treated as a success (unless
   /// [precondition] is specified, in which case it throws a [FirestoreException] with [FirestoreClientErrorCode.notFound]).
   void delete(
-    DocumentReference<Map<String, dynamic>> documentRef, {
+    DocumentReference<Object?> documentRef, {
     Precondition? precondition,
   }) {
     if (_writeBatch == null) {

--- a/packages/google_cloud_firestore/test/transaction_test.dart
+++ b/packages/google_cloud_firestore/test/transaction_test.dart
@@ -89,8 +89,7 @@ void main() {
       });
 
       test('delete() throws on read-only transaction', () {
-        final docRef =
-            firestore.doc('col/doc') as DocumentReference<Map<String, dynamic>>;
+        final docRef = firestore.doc('col/doc');
         expect(
           () => readOnlyTx.delete(docRef),
           throwsA(isA<FirestoreException>()),


### PR DESCRIPTION
Fixes #282.

Aligns the documentRef parameter type on `Transaction.delete` and `Transaction.update` to `DocumentReference<Object?>`, consistent with WriteBatch and BulkWriter.