### PR TITLE
feat(firestore): support typed refs in Transaction.delete and .update

### DIFF
--- a/packages/google_cloud_firestore/CHANGELOG.md
+++ b/packages/google_cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Updated `Transaction.delete` and `Transaction.update` type constraints to accept `DocumentReference<Object?>`. (thanks to @Levin-Me)
+
 ## 0.5.2
 
 - Fixed `Firestore.projectId` not reading `GOOGLE_CLOUD_PROJECT` when using Application Default Credentials locally.

--- a/packages/google_cloud_firestore/lib/src/transaction.dart
+++ b/packages/google_cloud_firestore/lib/src/transaction.dart
@@ -256,7 +256,7 @@ class Transaction {
   /// A [Precondition] restricting this update.
   ///
   void update(
-    DocumentReference<dynamic> documentRef,
+    DocumentReference<Object?> documentRef,
     Map<Object?, Object?> data, {
     Precondition? precondition,
   }) {
@@ -277,7 +277,7 @@ class Transaction {
   /// A delete for a non-existing document is treated as a success (unless
   /// [precondition] is specified, in which case it throws a [FirestoreException] with [FirestoreClientErrorCode.notFound]).
   void delete(
-    DocumentReference<Map<String, dynamic>> documentRef, {
+    DocumentReference<Object?> documentRef, {
     Precondition? precondition,
   }) {
     if (_writeBatch == null) {

--- a/packages/google_cloud_firestore/test/transaction_test.dart
+++ b/packages/google_cloud_firestore/test/transaction_test.dart
@@ -89,8 +89,7 @@ void main() {
       });
 
       test('delete() throws on read-only transaction', () {
-        final docRef =
-            firestore.doc('col/doc') as DocumentReference<Map<String, dynamic>>;
+        final docRef = firestore.doc('col/doc');
         expect(
           () => readOnlyTx.delete(docRef),
           throwsA(isA<FirestoreException>()),


### PR DESCRIPTION
Relax the accepted `DocumentReference` type constraint for `Transaction.delete` so it can be called with a typed document reference created via `withConverter`.

`Transaction.update` has also been aligned with the underlying `WriteBatch` API by accepting `DocumentReference<Object?>` instead of a dynamically typed reference `DocumentReference<dynamic>`.

## Related Issues

fixes #282 

## Checklist

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
