### PR TITLE
fix(firestore): retry reads on transient connection-closed errors

### DIFF
--- a/packages/google_cloud_firestore/CHANGELOG.md
+++ b/packages/google_cloud_firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fixed intermittent `ClientException: Connection closed before full header was received` on queries and aggregations under high concurrency; these now retry with backoff.
 - Updated `Transaction.delete` and `Transaction.update` type constraints to accept `DocumentReference<Object?>`. (thanks to @Levin-Me)
 - Made `Timestamp` encodable by adding `toJson` method. (thanks to @OutdatedGuy)
 

--- a/packages/google_cloud_firestore/CHANGELOG.md
+++ b/packages/google_cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fixed intermittent `ClientException: Connection closed before full header was received` on queries and aggregations under high concurrency; these now retry with backoff.
+- Fixed `Firestore.getAll()` retrying transient errors indefinitely; it now retries a bounded number of times before surfacing the error.
 - Updated `Transaction.delete` and `Transaction.update` type constraints to accept `DocumentReference<Object?>`. (thanks to @Levin-Me)
 - Made `Timestamp` encodable by adding `toJson` method. (thanks to @OutdatedGuy)
 

--- a/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
@@ -60,49 +60,55 @@ class _AggregationReader {
       transactionOptions: transactionOptions,
     );
 
-    final response = await aggregateQuery.query.firestore._firestoreClient.v1((
-      api,
-      projectId,
-    ) async {
-      return api.runAggregationQuery(request);
-    });
-
     final results = <String, Object?>{};
-    Timestamp? aggregationReadTime;
 
-    // Process streaming response
-    await for (final result in response) {
-      // Capture transaction ID from response (if present)
-      if (result.transaction.isNotEmpty) {
-        _retrievedTransactionId = base64Encode(result.transaction);
-      }
+    return retryOnConnectionError(
+      () async {
+        results.clear();
+        Timestamp? aggregationReadTime;
 
-      if (result.result != null) {
-        for (final entry in result.result!.aggregateFields.entries) {
-          final value = entry.value;
-          if (value.integerValue != null) {
-            results[entry.key] = value.integerValue;
-          } else if (value.doubleValue != null) {
-            results[entry.key] = value.doubleValue;
-          } else if (value.nullValue != null) {
-            results[entry.key] = null;
+        final response = await aggregateQuery.query.firestore._firestoreClient
+            .v1((api, projectId) async {
+              return api.runAggregationQuery(request);
+            });
+
+        // Process streaming response
+        await for (final result in response) {
+          // Capture transaction ID from response (if present)
+          if (result.transaction.isNotEmpty) {
+            _retrievedTransactionId = base64Encode(result.transaction);
+          }
+
+          if (result.result != null) {
+            for (final entry in result.result!.aggregateFields.entries) {
+              final value = entry.value;
+              if (value.integerValue != null) {
+                results[entry.key] = value.integerValue;
+              } else if (value.doubleValue != null) {
+                results[entry.key] = value.doubleValue;
+              } else if (value.nullValue != null) {
+                results[entry.key] = null;
+              }
+            }
+          }
+
+          if (result.readTime != null) {
+            aggregationReadTime = Timestamp._fromProto(result.readTime!);
           }
         }
-      }
 
-      if (result.readTime != null) {
-        aggregationReadTime = Timestamp._fromProto(result.readTime!);
-      }
-    }
-
-    // Return both aggregation results and transaction ID
-    return _AggregationReaderResponse(
-      AggregateQuerySnapshot._(
-        query: aggregateQuery,
-        readTime: aggregationReadTime,
-        data: results,
-      ),
-      _retrievedTransactionId,
+        // Return both aggregation results and transaction ID
+        return _AggregationReaderResponse(
+          AggregateQuerySnapshot._(
+            query: aggregateQuery,
+            readTime: aggregationReadTime,
+            data: results,
+          ),
+          _retrievedTransactionId,
+        );
+      },
+      hasPartialProgress: () => results.isNotEmpty,
+      allowRetry: transactionId == null && transactionOptions == null,
     );
   }
 }

--- a/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/aggregation_reader.dart
@@ -65,6 +65,7 @@ class _AggregationReader {
     return retryOnConnectionError(
       () async {
         results.clear();
+        _retrievedTransactionId = null;
         Timestamp? aggregationReadTime;
 
         final response = await aggregateQuery.query.firestore._firestoreClient

--- a/packages/google_cloud_firestore/lib/src/document_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/document_reader.dart
@@ -79,75 +79,81 @@ class _DocumentReader<T> {
   Future<void> _fetchDocuments() async {
     if (_outstandingDocuments.isEmpty) return;
 
-    final request = firestore_v1.BatchGetDocumentsRequest(
-      database: firestore._formattedDatabaseName,
-      documents: _outstandingDocuments.toList(),
-      mask: fieldMask.let((fieldMask) {
-        return firestore_v1.DocumentMask(
-          fieldPaths: fieldMask.map((e) => e._formattedName).toList(),
-        );
-      }),
-      transaction: transactionId.let(base64Decode),
-      newTransaction: transactionOptions,
-      readTime: readTime?._toProto().timestampValue,
-    );
-
+    // Each attempt only requests documents still outstanding from the
+    // previous one, since already-received documents are removed below.
     var resultCount = 0;
-    try {
-      final documents = await firestore._firestoreClient.v1((
-        api,
-        projectId,
-      ) async {
-        return api.batchGetDocuments(request);
-      });
 
-      await for (final response in documents) {
-        DocumentSnapshot<DocumentData>? documentSnapshot;
+    await const RetryOptions(maxAttempts: 5).retry(
+      () async {
+        // A prior failed attempt may have already fetched every outstanding
+        // document before erroring; nothing left to (re)request.
+        if (_outstandingDocuments.isEmpty) return;
 
-        if (response.transaction.isNotEmpty) {
-          _retrievedTransactionId = base64Encode(response.transaction);
+        resultCount = 0;
+
+        final request = firestore_v1.BatchGetDocumentsRequest(
+          database: firestore._formattedDatabaseName,
+          documents: _outstandingDocuments.toList(),
+          mask: fieldMask.let((fieldMask) {
+            return firestore_v1.DocumentMask(
+              fieldPaths: fieldMask.map((e) => e._formattedName).toList(),
+            );
+          }),
+          transaction: transactionId.let(base64Decode),
+          newTransaction: transactionOptions,
+          readTime: readTime?._toProto().timestampValue,
+        );
+
+        final documents = await firestore._firestoreClient.v1((
+          api,
+          projectId,
+        ) async {
+          return api.batchGetDocuments(request);
+        });
+
+        await for (final response in documents) {
+          DocumentSnapshot<DocumentData>? documentSnapshot;
+
+          if (response.transaction.isNotEmpty) {
+            _retrievedTransactionId = base64Encode(response.transaction);
+          }
+
+          final found = response.found;
+          if (found != null) {
+            documentSnapshot = DocumentSnapshot._fromDocument(
+              found,
+              response.readTime,
+              firestore,
+            );
+          } else if (response.missing != null && response.missing!.isNotEmpty) {
+            final missing = response.missing!;
+            documentSnapshot = DocumentSnapshot._missing(
+              missing,
+              response.readTime,
+              firestore,
+            );
+          }
+
+          if (documentSnapshot != null) {
+            final path = documentSnapshot.ref._formattedName;
+            _outstandingDocuments.remove(path);
+            _retreivedDocuments[path] = documentSnapshot;
+            resultCount++;
+          }
         }
-
-        final found = response.found;
-        if (found != null) {
-          documentSnapshot = DocumentSnapshot._fromDocument(
-            found,
-            response.readTime,
-            firestore,
-          );
-        } else if (response.missing != null && response.missing!.isNotEmpty) {
-          final missing = response.missing!;
-          documentSnapshot = DocumentSnapshot._missing(
-            missing,
-            response.readTime,
-            firestore,
-          );
-        }
-
-        if (documentSnapshot != null) {
-          final path = documentSnapshot.ref._formattedName;
-          _outstandingDocuments.remove(path);
-          _retreivedDocuments[path] = documentSnapshot;
-          resultCount++;
-        }
-      }
-    } on FirestoreException catch (firestoreError) {
-      final shouldRetry =
+      },
+      retryIf: (error) => switch (error) {
+        FirestoreException(:final errorCode) =>
           // Transactional reads are retried via the transaction runner
-          request.transaction == null &&
-          request.newTransaction == null &&
-          // Only retry if we made progress
-          resultCount > 0 &&
-          // Don't retry permanent errors
-          StatusCode.batchGetRetryCodes.contains(
-            firestoreError.errorCode.statusCode,
-          );
-
-      if (shouldRetry) {
-        return _fetchDocuments();
-      } else {
-        rethrow;
-      }
-    }
+          transactionId == null &&
+              transactionOptions == null &&
+              // Only retry if we made progress
+              resultCount > 0 &&
+              // Don't retry permanent errors
+              StatusCode.batchGetRetryCodes.contains(errorCode.statusCode),
+        _ => false,
+      },
+      onRetry: backOffHardOnResourceExhausted,
+    );
   }
 }

--- a/packages/google_cloud_firestore/lib/src/firestore.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore.dart
@@ -23,6 +23,7 @@ import 'package:google_cloud_protobuf/protobuf.dart' as protobuf_v1;
 import 'package:google_cloud_type/type.dart' as type_v1;
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 
 import 'backoff.dart';
 import 'credential.dart';

--- a/packages/google_cloud_firestore/lib/src/firestore_exception.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_exception.dart
@@ -159,19 +159,19 @@ Future<T> retryOnConnectionError<T>(
   int maxAttempts = 5,
 }) async {
   final backoff = ExponentialBackoff();
-  http.ClientException? lastError;
 
   for (var i = 0; i < maxAttempts; i++) {
     try {
-      await maybeBackoff(backoff);
+      if (i > 0) await maybeBackoff(backoff);
       return await attempt();
-    } on http.ClientException catch (error) {
-      lastError = error;
-      if (!allowRetry || hasPartialProgress()) rethrow;
+    } on http.ClientException {
+      if (!allowRetry || hasPartialProgress() || i == maxAttempts - 1) {
+        rethrow;
+      }
     }
   }
 
-  throw lastError!;
+  throw StateError('Unreachable');
 }
 
 /// Exception thrown by Firestore operations.

--- a/packages/google_cloud_firestore/lib/src/firestore_exception.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_exception.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 
 import 'backoff.dart';
 import 'status_code.dart';
@@ -126,16 +127,28 @@ Never handleFirestoreException(Object exception, StackTrace stackTrace) {
   Error.throwWithStackTrace(exception, stackTrace);
 }
 
-/// Delays further operations based on the provided error.
+/// The maximum delay between retries for Firestore's own retryable errors
+/// (as opposed to `package:retry`'s smaller 30s default), matching the
+/// ceiling this package has historically used.
+const _maxFirestoreRetryDelay = Duration(
+  milliseconds: ExponentialBackoff.defaultBackOffMaxDelayMs,
+);
+
+/// An `onRetry` callback for `package:retry` that makes RESOURCE_EXHAUSTED
+/// errors back off aggressively (jump straight to the max delay) rather than
+/// the standard gradual ramp-up.
+///
+/// RESOURCE_EXHAUSTED means the server has explicitly signaled it's over
+/// quota — retrying again quickly only adds more load and fails again, so
+/// this waits the maximum delay on top of `package:retry`'s own delay for
+/// that attempt before trying again.
 @internal
-Future<void> maybeBackoff(
-  ExponentialBackoff backoff, [
-  FirestoreException? error,
-]) async {
-  if (error?.errorCode.statusCode == StatusCode.resourceExhausted) {
-    backoff.resetToMax();
+Future<void> backOffHardOnResourceExhausted(Exception error) async {
+  if (error case FirestoreException(
+    :final errorCode,
+  ) when errorCode.statusCode == StatusCode.resourceExhausted) {
+    await Future<void>.delayed(_maxFirestoreRetryDelay);
   }
-  await backoff.backoffAndWait();
 }
 
 /// Retries [attempt] with backoff when it throws a transport-level
@@ -157,21 +170,12 @@ Future<T> retryOnConnectionError<T>(
   required bool Function() hasPartialProgress,
   bool allowRetry = true,
   int maxAttempts = 5,
-}) async {
-  final backoff = ExponentialBackoff();
-
-  for (var i = 0; i < maxAttempts; i++) {
-    try {
-      if (i > 0) await maybeBackoff(backoff);
-      return await attempt();
-    } on http.ClientException {
-      if (!allowRetry || hasPartialProgress() || i == maxAttempts - 1) {
-        rethrow;
-      }
-    }
-  }
-
-  throw StateError('Unreachable');
+}) {
+  return RetryOptions(maxAttempts: maxAttempts).retry(
+    attempt,
+    retryIf: (error) =>
+        error is http.ClientException && allowRetry && !hasPartialProgress(),
+  );
 }
 
 /// Exception thrown by Firestore operations.

--- a/packages/google_cloud_firestore/lib/src/firestore_exception.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_exception.dart
@@ -15,8 +15,10 @@
 import 'dart:convert';
 
 import 'package:google_cloud_rpc/exceptions.dart';
+import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
+import 'backoff.dart';
 import 'status_code.dart';
 
 /// Extracts error code from error response.
@@ -122,6 +124,54 @@ Never handleFirestoreException(Object exception, StackTrace stackTrace) {
   }
 
   Error.throwWithStackTrace(exception, stackTrace);
+}
+
+/// Delays further operations based on the provided error.
+@internal
+Future<void> maybeBackoff(
+  ExponentialBackoff backoff, [
+  FirestoreException? error,
+]) async {
+  if (error?.errorCode.statusCode == StatusCode.resourceExhausted) {
+    backoff.resetToMax();
+  }
+  await backoff.backoffAndWait();
+}
+
+/// Retries [attempt] with backoff when it throws a transport-level
+/// [http.ClientException] (e.g. a keep-alive connection dropped before any
+/// response was received) — see
+/// https://github.com/firebase/firebase-admin-dart/issues/291.
+///
+/// [attempt] must reset any state it accumulates (e.g. clear a results list)
+/// at the start of each call, since it may be invoked multiple times.
+///
+/// Retrying is only safe when [hasPartialProgress] reports that no data has
+/// been streamed back yet in the failed attempt (otherwise retrying would
+/// duplicate already-received results), and when [allowRetry] is true (reads
+/// within an active transaction are instead retried by the transaction
+/// runner).
+@internal
+Future<T> retryOnConnectionError<T>(
+  Future<T> Function() attempt, {
+  required bool Function() hasPartialProgress,
+  bool allowRetry = true,
+  int maxAttempts = 5,
+}) async {
+  final backoff = ExponentialBackoff();
+  http.ClientException? lastError;
+
+  for (var i = 0; i < maxAttempts; i++) {
+    try {
+      await maybeBackoff(backoff);
+      return await attempt();
+    } on http.ClientException catch (error) {
+      lastError = error;
+      if (!allowRetry || hasPartialProgress()) rethrow;
+    }
+  }
+
+  throw lastError!;
 }
 
 /// Exception thrown by Firestore operations.

--- a/packages/google_cloud_firestore/lib/src/query_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/query_reader.dart
@@ -65,6 +65,7 @@ class _QueryReader<T> {
     return retryOnConnectionError(
       () async {
         snapshots.clear();
+        _retrievedTransactionId = null;
         Timestamp? queryReadTime;
 
         final response = await query.firestore._firestoreClient.v1((

--- a/packages/google_cloud_firestore/lib/src/query_reader.dart
+++ b/packages/google_cloud_firestore/lib/src/query_reader.dart
@@ -60,61 +60,69 @@ class _QueryReader<T> {
       transactionOptions: transactionOptions,
     );
 
-    final response = await query.firestore._firestoreClient.v1((
-      api,
-      projectId,
-    ) async {
-      return api.runQuery(request);
-    });
-
-    Timestamp? queryReadTime;
     final snapshots = <QueryDocumentSnapshot<T>>[];
 
-    // Process streaming response
-    await for (final e in response) {
-      // Capture transaction ID from response (if present)
-      if (e.transaction.isNotEmpty) {
-        _retrievedTransactionId = base64Encode(e.transaction);
-      }
+    return retryOnConnectionError(
+      () async {
+        snapshots.clear();
+        Timestamp? queryReadTime;
 
-      final document = e.document;
-      if (document == null) {
-        // End of stream marker
-        queryReadTime = e.readTime?.let(Timestamp._fromProto);
-        continue;
-      }
+        final response = await query.firestore._firestoreClient.v1((
+          api,
+          projectId,
+        ) async {
+          return api.runQuery(request);
+        });
 
-      // Convert proto document to DocumentSnapshot
-      final snapshot = DocumentSnapshot._fromDocument(
-        document,
-        e.readTime,
-        query.firestore,
-      );
+        // Process streaming response
+        await for (final e in response) {
+          // Capture transaction ID from response (if present)
+          if (e.transaction.isNotEmpty) {
+            _retrievedTransactionId = base64Encode(e.transaction);
+          }
 
-      // Recreate with proper converter
-      final finalDoc =
-          _DocumentSnapshotBuilder(
-              snapshot.ref.withConverter<T>(
-                fromFirestore: query._queryOptions.converter.fromFirestore,
-                toFirestore: query._queryOptions.converter.toFirestore,
-              ),
-            )
-            ..fieldsProto = firestore_v1.MapValue(fields: document.fields)
-            ..readTime = snapshot.readTime
-            ..createTime = snapshot.createTime
-            ..updateTime = snapshot.updateTime;
+          final document = e.document;
+          if (document == null) {
+            // End of stream marker
+            queryReadTime = e.readTime?.let(Timestamp._fromProto);
+            continue;
+          }
 
-      snapshots.add(finalDoc.build() as QueryDocumentSnapshot<T>);
-    }
+          // Convert proto document to DocumentSnapshot
+          final snapshot = DocumentSnapshot._fromDocument(
+            document,
+            e.readTime,
+            query.firestore,
+          );
 
-    // Return both query results and transaction ID
-    return _QueryReaderResponse<T>(
-      QuerySnapshot<T>._(
-        query: query,
-        readTime: queryReadTime,
-        docs: snapshots,
-      ),
-      _retrievedTransactionId,
+          // Recreate with proper converter
+          final finalDoc =
+              _DocumentSnapshotBuilder(
+                  snapshot.ref.withConverter<T>(
+                    fromFirestore: query._queryOptions.converter.fromFirestore,
+                    toFirestore: query._queryOptions.converter.toFirestore,
+                  ),
+                )
+                ..fieldsProto = firestore_v1.MapValue(fields: document.fields)
+                ..readTime = snapshot.readTime
+                ..createTime = snapshot.createTime
+                ..updateTime = snapshot.updateTime;
+
+          snapshots.add(finalDoc.build() as QueryDocumentSnapshot<T>);
+        }
+
+        // Return both query results and transaction ID
+        return _QueryReaderResponse<T>(
+          QuerySnapshot<T>._(
+            query: query,
+            readTime: queryReadTime,
+            docs: snapshots,
+          ),
+          _retrievedTransactionId,
+        );
+      },
+      hasPartialProgress: () => snapshots.isNotEmpty,
+      allowRetry: transactionId == null && transactionOptions == null,
     );
   }
 }

--- a/packages/google_cloud_firestore/lib/src/reference/aggregate_query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/aggregate_query.dart
@@ -130,40 +130,44 @@ class AggregateQuery {
       readTime: null,
     );
 
-    final response = await firestore._firestoreClient.v1((
-      api,
-      projectId,
-    ) async {
-      return api.runAggregationQuery(request);
-    });
-
     final results = <String, Object?>{};
-    Timestamp? readTime;
 
-    await for (final result in response) {
-      if (result.result case final aggregationResult?) {
-        for (final entry in aggregationResult.aggregateFields.entries) {
-          final value = entry.value;
-          if (value.integerValue != null) {
-            results[entry.key] = value.integerValue;
-          } else if (value.doubleValue != null) {
-            results[entry.key] = value.doubleValue;
-          } else if (value.nullValue != null) {
-            results[entry.key] = null;
+    return retryOnConnectionError(() async {
+      results.clear();
+      Timestamp? readTime;
+
+      final response = await firestore._firestoreClient.v1((
+        api,
+        projectId,
+      ) async {
+        return api.runAggregationQuery(request);
+      });
+
+      await for (final result in response) {
+        if (result.result case final aggregationResult?) {
+          for (final entry in aggregationResult.aggregateFields.entries) {
+            final value = entry.value;
+            if (value.integerValue != null) {
+              results[entry.key] = value.integerValue;
+            } else if (value.doubleValue != null) {
+              results[entry.key] = value.doubleValue;
+            } else if (value.nullValue != null) {
+              results[entry.key] = null;
+            }
           }
+        }
+
+        if (result.readTime != null) {
+          readTime = Timestamp._fromProto(result.readTime!);
         }
       }
 
-      if (result.readTime != null) {
-        readTime = Timestamp._fromProto(result.readTime!);
-      }
-    }
-
-    return AggregateQuerySnapshot._(
-      query: this,
-      readTime: readTime,
-      data: results,
-    );
+      return AggregateQuerySnapshot._(
+        query: this,
+        readTime: readTime,
+        data: results,
+      );
+    }, hasPartialProgress: () => results.isNotEmpty);
   }
 
   /// Converts this aggregation query to a proto representation.

--- a/packages/google_cloud_firestore/lib/src/reference/query.dart
+++ b/packages/google_cloud_firestore/lib/src/reference/query.dart
@@ -480,50 +480,64 @@ interface class Query<T> {
   }
 
   Future<QuerySnapshot<T>> _get({required String? transactionId}) async {
-    final response = await firestore._firestoreClient.v1((
-      api,
-      projectId,
-    ) async {
-      final request = _toProto(
-        parent: _buildProtoParentPath(),
-        transactionId: transactionId,
-        readTime: null,
-      );
-      return api.runQuery(request);
-    });
+    final request = _toProto(
+      parent: _buildProtoParentPath(),
+      transactionId: transactionId,
+      readTime: null,
+    );
 
-    Timestamp? readTime;
     final snapshots = <QueryDocumentSnapshot<T>>[];
-    await for (final e in response) {
-      final document = e.document;
-      if (document == null) {
-        readTime = e.readTime.let(Timestamp._fromProto);
-        continue;
-      }
 
-      final snapshot = DocumentSnapshot._fromDocument(
-        document,
-        e.readTime,
-        firestore,
-      );
-      final finalDoc =
-          _DocumentSnapshotBuilder(
-              snapshot.ref.withConverter<T>(
-                fromFirestore: _queryOptions.converter.fromFirestore,
-                toFirestore: _queryOptions.converter.toFirestore,
-              ),
-            )
-            // Recreate the QueryDocumentSnapshot with the DocumentReference
-            // containing the original converter.
-            ..fieldsProto = firestore_v1.MapValue(fields: document.fields)
-            ..readTime = snapshot.readTime
-            ..createTime = snapshot.createTime
-            ..updateTime = snapshot.updateTime;
+    return retryOnConnectionError(
+      () async {
+        snapshots.clear();
+        Timestamp? readTime;
 
-      snapshots.add(finalDoc.build() as QueryDocumentSnapshot<T>);
-    }
+        final response = await firestore._firestoreClient.v1((
+          api,
+          projectId,
+        ) async {
+          return api.runQuery(request);
+        });
 
-    return QuerySnapshot<T>._(query: this, readTime: readTime, docs: snapshots);
+        await for (final e in response) {
+          final document = e.document;
+          if (document == null) {
+            readTime = e.readTime.let(Timestamp._fromProto);
+            continue;
+          }
+
+          final snapshot = DocumentSnapshot._fromDocument(
+            document,
+            e.readTime,
+            firestore,
+          );
+          final finalDoc =
+              _DocumentSnapshotBuilder(
+                  snapshot.ref.withConverter<T>(
+                    fromFirestore: _queryOptions.converter.fromFirestore,
+                    toFirestore: _queryOptions.converter.toFirestore,
+                  ),
+                )
+                // Recreate the QueryDocumentSnapshot with the
+                // DocumentReference containing the original converter.
+                ..fieldsProto = firestore_v1.MapValue(fields: document.fields)
+                ..readTime = snapshot.readTime
+                ..createTime = snapshot.createTime
+                ..updateTime = snapshot.updateTime;
+
+          snapshots.add(finalDoc.build() as QueryDocumentSnapshot<T>);
+        }
+
+        return QuerySnapshot<T>._(
+          query: this,
+          readTime: readTime,
+          docs: snapshots,
+        );
+      },
+      hasPartialProgress: () => snapshots.isNotEmpty,
+      allowRetry: transactionId == null,
+    );
   }
 
   String _buildProtoParentPath() {

--- a/packages/google_cloud_firestore/lib/src/transaction.dart
+++ b/packages/google_cloud_firestore/lib/src/transaction.dart
@@ -55,7 +55,6 @@ class Transaction {
         _writeBatch = null;
       default:
         _writeBatch = WriteBatch._(_firestore);
-        _backoff = ExponentialBackoff();
     }
   }
 
@@ -77,9 +76,6 @@ class Transaction {
 
   /// `null` if transaction is read only
   late final WriteBatch? _writeBatch;
-
-  /// `null` if transaction is read only
-  late final ExponentialBackoff _backoff;
 
   /// Future that resolves to the transaction ID of the current attempt.
   /// It is lazily initialised upon the first read. Upon retry, it is reset and
@@ -521,30 +517,31 @@ class Transaction {
 
   Future<T> _runTransaction<T>(TransactionHandler<T> updateFunction) async {
     // No backoff is set for readonly transactions (i.e. attempts == 1)
-    if (_writeBatch == null) {
+    final writeBatch = _writeBatch;
+    if (writeBatch == null) {
       return _runTransactionOnce(updateFunction);
     }
-    FirestoreException? lastError;
 
-    for (var attempts = 0; attempts < _maxAttempts; attempts++) {
-      try {
-        _writeBatch.reset();
-        await maybeBackoff(_backoff, lastError);
-
-        return await _runTransactionOnce(updateFunction);
-      } on FirestoreException catch (e) {
-        lastError = e;
-
-        if (!_isRetryableTransactionError(e)) {
-          rethrow;
-        }
+    try {
+      return await RetryOptions(maxAttempts: _maxAttempts).retry(
+        () {
+          writeBatch.reset();
+          return _runTransactionOnce(updateFunction);
+        },
+        retryIf: (error) =>
+            error is FirestoreException && _isRetryableTransactionError(error),
+        onRetry: backOffHardOnResourceExhausted,
+      );
+    } on FirestoreException catch (e) {
+      if (_isRetryableTransactionError(e)) {
+        // All attempts were exhausted on a retryable error.
+        throw FirestoreException(
+          FirestoreClientErrorCode.aborted,
+          'Transaction max attempts exceeded',
+        );
       }
+      rethrow;
     }
-
-    throw FirestoreException(
-      FirestoreClientErrorCode.aborted,
-      'Transaction max attempts exceeded',
-    );
   }
 
   Future<T> _runTransactionOnce<T>(TransactionHandler<T> updateFunction) async {

--- a/packages/google_cloud_firestore/lib/src/transaction.dart
+++ b/packages/google_cloud_firestore/lib/src/transaction.dart
@@ -529,7 +529,7 @@ class Transaction {
     for (var attempts = 0; attempts < _maxAttempts; attempts++) {
       try {
         _writeBatch.reset();
-        await _maybeBackoff(_backoff, lastError);
+        await maybeBackoff(_backoff, lastError);
 
         return await _runTransactionOnce(updateFunction);
       } on FirestoreException catch (e) {
@@ -565,17 +565,6 @@ class Transaction {
 /// The [TransactionHandler] may be executed multiple times; it should be able
 /// to handle multiple executions.
 typedef TransactionHandler<T> = Future<T> Function(Transaction transaction);
-
-/// Delays further operations based on the provided error.
-Future<void> _maybeBackoff(
-  ExponentialBackoff backoff, [
-  FirestoreException? error,
-]) async {
-  if (error?.errorCode.statusCode == StatusCode.resourceExhausted) {
-    backoff.resetToMax();
-  }
-  await backoff.backoffAndWait();
-}
 
 bool _isRetryableTransactionError(FirestoreException error) {
   switch (error.errorCode.statusCode) {

--- a/packages/google_cloud_firestore/lib/src/write_batch.dart
+++ b/packages/google_cloud_firestore/lib/src/write_batch.dart
@@ -128,26 +128,19 @@ class WriteBatch {
     }
 
     const retryCodes = StatusCode.resourceExhaustedAbortedUnavailable;
-    const maxAttempts = 5;
 
-    final backoff = ExponentialBackoff();
-    FirestoreException? lastError;
-
-    for (var attempt = 0; attempt < maxAttempts; attempt++) {
-      try {
-        await maybeBackoff(backoff, lastError);
-        return await firestore._firestoreClient.v1((api, projectId) async {
-          return api.commit(request);
-        });
-      } on FirestoreException catch (e) {
-        lastError = e;
-        if (!retryCodes.contains(e.errorCode.statusCode)) {
-          rethrow;
-        }
-      }
-    }
-
-    throw lastError!;
+    return const RetryOptions(maxAttempts: 5).retry(
+      () => firestore._firestoreClient.v1((api, projectId) async {
+        return api.commit(request);
+      }),
+      retryIf: (error) => switch (error) {
+        FirestoreException(:final errorCode) => retryCodes.contains(
+          errorCode.statusCode,
+        ),
+        _ => false,
+      },
+      onRetry: backOffHardOnResourceExhausted,
+    );
   }
 
   ///Resets the WriteBatch and dequeues all pending operations.

--- a/packages/google_cloud_firestore/lib/src/write_batch.dart
+++ b/packages/google_cloud_firestore/lib/src/write_batch.dart
@@ -135,7 +135,7 @@ class WriteBatch {
 
     for (var attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        await _maybeBackoff(backoff, lastError);
+        await maybeBackoff(backoff, lastError);
         return await firestore._firestoreClient.v1((api, projectId) async {
           return api.commit(request);
         });

--- a/packages/google_cloud_firestore/pubspec.yaml
+++ b/packages/google_cloud_firestore/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http: ^1.6.0
   intl: ^0.20.0
   meta: ^1.17.0
+  retry: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.7

--- a/packages/google_cloud_firestore/test/aggregate_query_test.dart
+++ b/packages/google_cloud_firestore/test/aggregate_query_test.dart
@@ -12,15 +12,91 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@Tags(['firebase-emulator'])
-library;
-
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:google_cloud_firestore/src/firestore_http_client.dart';
+import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/helpers.dart';
 
+class MockFirestoreHttpClient extends Mock implements FirestoreHttpClient {}
+
+firestore_v1.RunAggregationQueryResponse _countResponse(int count) {
+  return firestore_v1.RunAggregationQueryResponse(
+    result: firestore_v1.AggregationResult(
+      aggregateFields: {'count': firestore_v1.Value(integerValue: count)},
+    ),
+  );
+}
+
+final _connectionClosedError = http.ClientException(
+  'Connection closed before full header was received',
+);
+
 void main() {
+  group(
+    'AggregateQuery.get() retries on transient connection errors (unit)',
+    () {
+      late MockFirestoreHttpClient mockClient;
+      late Firestore firestore;
+
+      setUp(() {
+        mockClient = MockFirestoreHttpClient();
+        firestore = Firestore.internal(
+          settings: const Settings(projectId: mockProjectId),
+          client: mockClient,
+        );
+
+        when(() => mockClient.cachedProjectId).thenReturn(mockProjectId);
+      });
+
+      test('retries once and succeeds after a ClientException', () async {
+        var callCount = 0;
+        when(
+          () => mockClient.v1<Stream<firestore_v1.RunAggregationQueryResponse>>(
+            any(),
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) {
+            return Stream<firestore_v1.RunAggregationQueryResponse>.error(
+              _connectionClosedError,
+            );
+          }
+          return Stream.fromIterable([_countResponse(42)]);
+        });
+
+        final snapshot = await firestore.collection('numbers').count().get();
+
+        expect(callCount, 2);
+        expect(snapshot.count, 42);
+      });
+
+      test('gives up and rethrows after repeated ClientExceptions', () async {
+        var callCount = 0;
+        when(
+          () => mockClient.v1<Stream<firestore_v1.RunAggregationQueryResponse>>(
+            any(),
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          return Stream<firestore_v1.RunAggregationQueryResponse>.error(
+            _connectionClosedError,
+          );
+        });
+
+        await expectLater(
+          firestore.collection('numbers').count().get(),
+          throwsA(isA<http.ClientException>()),
+        );
+
+        expect(callCount, greaterThan(1));
+      });
+    },
+  );
+
   group('AggregateQuery', () {
     late Firestore firestore;
     late CollectionReference<DocumentData> collection;
@@ -875,5 +951,5 @@ void main() {
         expect(() => collection.average(123), throwsA(isA<AssertionError>()));
       });
     });
-  });
+  }, tags: 'firebase-emulator');
 }

--- a/packages/google_cloud_firestore/test/fixtures/helpers.dart
+++ b/packages/google_cloud_firestore/test/fixtures/helpers.dart
@@ -20,6 +20,11 @@ import 'package:test/test.dart';
 
 const projectId = 'dart-firebase-admin';
 
+/// Project ID used by unit tests that mock the Firestore HTTP client and
+/// never make a real network call (as opposed to [projectId], which points
+/// at the real project used by emulator/production integration tests).
+const mockProjectId = 'test-project';
+
 /// Whether the Firestore emulator is enabled.
 bool isFirestoreEmulatorEnabled() {
   return Platform.environment['FIRESTORE_EMULATOR_HOST'] != null;

--- a/packages/google_cloud_firestore/test/get_all_test.dart
+++ b/packages/google_cloud_firestore/test/get_all_test.dart
@@ -62,6 +62,16 @@ firestore_v1.BatchGetDocumentsResponse createMissingResponse(
   );
 }
 
+/// A stream that yields [response] (simulating partial progress) then fails
+/// with a retryable [FirestoreException], as if the connection dropped
+/// mid-batch.
+Stream<firestore_v1.BatchGetDocumentsResponse> _partialThenUnavailable(
+  firestore_v1.BatchGetDocumentsResponse response,
+) async* {
+  yield response;
+  throw FirestoreException(FirestoreClientErrorCode.unavailable);
+}
+
 void main() {
   group('Firestore.getAll()', () {
     late MockFirestoreHttpClient mockClient;
@@ -319,6 +329,113 @@ void main() {
       // Should return successfully with field mask
       expect(results, hasLength(1));
       expect(results[0].get('foo')?.value, 'bar');
+    });
+  });
+
+  group('Firestore.getAll() retries on transient errors', () {
+    late MockFirestoreHttpClient mockClient;
+    late Firestore firestore;
+
+    setUp(() {
+      mockClient = MockFirestoreHttpClient();
+      firestore = Firestore.internal(
+        settings: const Settings(projectId: _unitTestProjectId),
+        client: mockClient,
+      );
+
+      when(() => mockClient.cachedProjectId).thenReturn(_unitTestProjectId);
+    });
+
+    test('retries after partial progress and succeeds', () async {
+      var callCount = 0;
+      when(
+        () => mockClient.v1<Stream<firestore_v1.BatchGetDocumentsResponse>>(
+          any(),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        if (callCount == 1) {
+          // First attempt fetches doc "a", then the connection drops before
+          // doc "b" is received.
+          return _partialThenUnavailable(
+            createFoundResponse(
+              documentPath: 'col/a',
+              fields: {'v': 1},
+              firestore: firestore,
+            ),
+          );
+        }
+        // Retry only re-requests the still-outstanding doc "b".
+        return Stream.fromIterable([
+          createFoundResponse(
+            documentPath: 'col/b',
+            fields: {'v': 2},
+            firestore: firestore,
+          ),
+        ]);
+      });
+
+      final docA = firestore.doc('col/a');
+      final docB = firestore.doc('col/b');
+      final results = await firestore.getAll([docA, docB]);
+
+      expect(callCount, 2);
+      expect(results, hasLength(2));
+      expect(results[0].get('v')?.value, 1);
+      expect(results[1].get('v')?.value, 2);
+    });
+
+    test('does not retry when no progress was made', () async {
+      var callCount = 0;
+      when(
+        () => mockClient.v1<Stream<firestore_v1.BatchGetDocumentsResponse>>(
+          any(),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        return Stream<firestore_v1.BatchGetDocumentsResponse>.error(
+          FirestoreException(FirestoreClientErrorCode.unavailable),
+        );
+      });
+
+      final doc = firestore.doc('col/a');
+
+      await expectLater(
+        firestore.getAll([doc]),
+        throwsA(isA<FirestoreException>()),
+      );
+
+      expect(callCount, 1);
+    });
+
+    test('gives up after max attempts (bounded, not infinite)', () async {
+      var callCount = 0;
+      when(
+        () => mockClient.v1<Stream<firestore_v1.BatchGetDocumentsResponse>>(
+          any(),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        // Doc "a" is (re-)found every attempt, but doc "b" is never
+        // returned, so this would previously have retried forever.
+        return _partialThenUnavailable(
+          createFoundResponse(
+            documentPath: 'col/a',
+            fields: {'v': 1},
+            firestore: firestore,
+          ),
+        );
+      });
+
+      final docA = firestore.doc('col/a');
+      final docB = firestore.doc('col/b');
+
+      await expectLater(
+        firestore.getAll([docA, docB]),
+        throwsA(isA<FirestoreException>()),
+      );
+
+      expect(callCount, 5);
     });
   });
 

--- a/packages/google_cloud_firestore/test/query_test.dart
+++ b/packages/google_cloud_firestore/test/query_test.dart
@@ -12,16 +12,116 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@Tags(['firebase-emulator'])
-library;
-
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:google_cloud_firestore/src/firestore_http_client.dart';
 import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
+import 'package:google_cloud_protobuf/protobuf.dart' as protobuf_v1;
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/helpers.dart';
 
+class MockFirestoreHttpClient extends Mock implements FirestoreHttpClient {}
+
+firestore_v1.RunQueryResponse _documentResponse({
+  required String documentPath,
+  required Map<String, Object?> fields,
+  required Firestore firestore,
+}) {
+  final now = protobuf_v1.Timestamp(
+    seconds: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  );
+  return firestore_v1.RunQueryResponse(
+    document: firestore_v1.Document(
+      name:
+          'projects/$mockProjectId/databases/(default)/documents/$documentPath',
+      fields: fields.map((key, value) {
+        final encoded = firestore.serializer.encodeValue(value);
+        return MapEntry(key, encoded!);
+      }),
+      createTime: now,
+      updateTime: now,
+    ),
+    readTime: now,
+  );
+}
+
+final _connectionClosedError = http.ClientException(
+  'Connection closed before full header was received',
+);
+
 void main() {
+  group('Query.get() retries on transient connection errors (unit)', () {
+    late MockFirestoreHttpClient mockClient;
+    late Firestore firestore;
+
+    setUp(() {
+      mockClient = MockFirestoreHttpClient();
+      firestore = Firestore.internal(
+        settings: const Settings(projectId: mockProjectId),
+        client: mockClient,
+      );
+
+      when(() => mockClient.cachedProjectId).thenReturn(mockProjectId);
+    });
+
+    test('retries once and succeeds after a ClientException', () async {
+      var callCount = 0;
+      when(
+        () => mockClient.v1<Stream<firestore_v1.RunQueryResponse>>(any()),
+      ).thenAnswer((_) async {
+        callCount++;
+        if (callCount == 1) {
+          return Stream<firestore_v1.RunQueryResponse>.error(
+            _connectionClosedError,
+          );
+        }
+        return Stream.fromIterable([
+          _documentResponse(
+            documentPath: 'numbers/0',
+            fields: {'number': 0},
+            firestore: firestore,
+          ),
+        ]);
+      });
+
+      final snapshot = await firestore
+          .collection('numbers')
+          .where('number', WhereFilter.equal, 0)
+          .limit(1)
+          .get();
+
+      expect(callCount, 2);
+      expect(snapshot.docs, hasLength(1));
+      expect(snapshot.docs.single.get('number')?.value, 0);
+    });
+
+    test('gives up and rethrows after repeated ClientExceptions', () async {
+      var callCount = 0;
+      when(
+        () => mockClient.v1<Stream<firestore_v1.RunQueryResponse>>(any()),
+      ).thenAnswer((_) async {
+        callCount++;
+        return Stream<firestore_v1.RunQueryResponse>.error(
+          _connectionClosedError,
+        );
+      });
+
+      await expectLater(
+        firestore
+            .collection('numbers')
+            .where('number', WhereFilter.equal, 0)
+            .limit(1)
+            .get(),
+        throwsA(isA<http.ClientException>()),
+      );
+
+      // Retries a bounded number of times rather than forever or exactly once.
+      expect(callCount, greaterThan(1));
+    });
+  });
+
   group('query interface', () {
     late Firestore firestore;
 
@@ -230,7 +330,7 @@ void main() {
 
       expect(snapshot.docs.map((doc) => doc.id), ['2', '4', '5']);
     });
-  });
+  }, tags: 'firebase-emulator');
 
   group('where()', () {
     late Firestore firestore;
@@ -446,7 +546,7 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
-  });
+  }, tags: 'firebase-emulator');
 
   group('orderBy', () {
     late Firestore firestore;
@@ -494,7 +594,7 @@ void main() {
       final snapshot = await collection.orderBy('foo').orderBy('bar').get();
       expect(snapshot.docs.map((doc) => doc.id), ['d', 'c', 'b', 'a']);
     });
-  });
+  }, tags: 'firebase-emulator');
 
   group('limit()', () {
     late Firestore firestore;
@@ -511,7 +611,7 @@ void main() {
       final snapshot = await collection.limit(1).limit(2).get();
       expect(snapshot.docs.map((doc) => doc.id), ['a', 'b']);
     });
-  });
+  }, tags: 'firebase-emulator');
 
   group('limitToLatest()', () {
     late Firestore firestore;
@@ -532,5 +632,5 @@ void main() {
           .get();
       expect(snapshot.docs.map((doc) => doc.id), ['c', 'b']);
     });
-  });
+  }, tags: 'firebase-emulator');
 }

--- a/packages/google_cloud_firestore/test/transaction_aggregation_test.dart
+++ b/packages/google_cloud_firestore/test/transaction_aggregation_test.dart
@@ -12,15 +12,119 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@Tags(['firebase-emulator'])
-library;
+import 'dart:typed_data';
 
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:google_cloud_firestore/src/firestore_http_client.dart';
+import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/helpers.dart';
 
+class MockFirestoreHttpClient extends Mock implements FirestoreHttpClient {}
+
+final _connectionClosedError = http.ClientException(
+  'Connection closed before full header was received',
+);
+
 void main() {
+  group(
+    'Transaction.getAggregateQuery() retries on transient connection errors (unit)',
+    () {
+      late MockFirestoreHttpClient mockClient;
+      late Firestore firestore;
+
+      setUp(() {
+        mockClient = MockFirestoreHttpClient();
+        firestore = Firestore.internal(
+          settings: const Settings(projectId: mockProjectId),
+          client: mockClient,
+        );
+
+        when(() => mockClient.cachedProjectId).thenReturn(mockProjectId);
+      });
+
+      test(
+        'retries a read-only snapshot read (no active transaction) and succeeds',
+        () async {
+          var callCount = 0;
+          when(
+            () => mockClient
+                .v1<Stream<firestore_v1.RunAggregationQueryResponse>>(any()),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return Stream<firestore_v1.RunAggregationQueryResponse>.error(
+                _connectionClosedError,
+              );
+            }
+            return Stream.fromIterable([
+              firestore_v1.RunAggregationQueryResponse(
+                result: firestore_v1.AggregationResult(
+                  aggregateFields: {
+                    'count': firestore_v1.Value(integerValue: 42),
+                  },
+                ),
+              ),
+            ]);
+          });
+
+          final aggregateQuery = firestore.collection('numbers').count();
+          final snapshot = await firestore.runTransaction(
+            (tx) => tx.getAggregateQuery(aggregateQuery),
+            transactionOptions: ReadOnlyTransactionOptions(
+              readTime: Timestamp.now(),
+            ),
+          );
+
+          expect(callCount, 2);
+          expect(snapshot.count, 42);
+        },
+      );
+
+      test('does not retry a read within an active transaction', () async {
+        // The failed transaction attempt triggers a best-effort rollback.
+        when(() => mockClient.v1<void>(any())).thenAnswer((_) async {});
+
+        var callCount = 0;
+        when(
+          () => mockClient.v1<Stream<firestore_v1.RunAggregationQueryResponse>>(
+            any(),
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) {
+            // First read starts the transaction successfully.
+            return Stream.fromIterable([
+              firestore_v1.RunAggregationQueryResponse(
+                transaction: Uint8List.fromList([1, 2, 3]),
+              ),
+            ]);
+          }
+          // Second read, already inside the now-active transaction, fails
+          // and must not be retried by the reader itself.
+          return Stream<firestore_v1.RunAggregationQueryResponse>.error(
+            _connectionClosedError,
+          );
+        });
+
+        final aggregateQuery = firestore.collection('numbers').count();
+
+        await expectLater(
+          firestore.runTransaction((tx) async {
+            await tx.getAggregateQuery(aggregateQuery);
+            return tx.getAggregateQuery(aggregateQuery);
+          }),
+          throwsA(isA<http.ClientException>()),
+        );
+
+        expect(callCount, 2);
+      });
+    },
+  );
+
   group('Transaction - Aggregation Queries', () {
     late Firestore firestore;
     late CollectionReference<DocumentData> collection;
@@ -300,5 +404,5 @@ void main() {
       expect(result['docScore'], 80);
       expect(result['avgScore'], 85.0); // (80 + 90) / 2
     });
-  });
+  }, tags: 'firebase-emulator');
 }

--- a/packages/google_cloud_firestore/test/transaction_query_test.dart
+++ b/packages/google_cloud_firestore/test/transaction_query_test.dart
@@ -2,14 +2,109 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Tags(['firebase-emulator'])
-library;
+import 'dart:typed_data';
 
 import 'package:google_cloud_firestore/google_cloud_firestore.dart';
+import 'package:google_cloud_firestore/src/firestore_http_client.dart';
+import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'fixtures/helpers.dart' as helpers;
 
+class MockFirestoreHttpClient extends Mock implements FirestoreHttpClient {}
+
+final _connectionClosedError = http.ClientException(
+  'Connection closed before full header was received',
+);
+
 void main() {
+  group(
+    'Transaction.getQuery() retries on transient connection errors (unit)',
+    () {
+      late MockFirestoreHttpClient mockClient;
+      late Firestore firestore;
+
+      setUp(() {
+        mockClient = MockFirestoreHttpClient();
+        firestore = Firestore.internal(
+          settings: const Settings(projectId: helpers.mockProjectId),
+          client: mockClient,
+        );
+
+        when(
+          () => mockClient.cachedProjectId,
+        ).thenReturn(helpers.mockProjectId);
+      });
+
+      test(
+        'retries a read-only snapshot read (no active transaction) and succeeds',
+        () async {
+          var callCount = 0;
+          when(
+            () => mockClient.v1<Stream<firestore_v1.RunQueryResponse>>(any()),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return Stream<firestore_v1.RunQueryResponse>.error(
+                _connectionClosedError,
+              );
+            }
+            return Stream.fromIterable([firestore_v1.RunQueryResponse()]);
+          });
+
+          final query = firestore.collection('numbers');
+          final snapshot = await firestore.runTransaction(
+            (tx) => tx.getQuery(query),
+            transactionOptions: ReadOnlyTransactionOptions(
+              readTime: Timestamp.now(),
+            ),
+          );
+
+          expect(callCount, 2);
+          expect(snapshot.docs, isEmpty);
+        },
+      );
+
+      test('does not retry a read within an active transaction', () async {
+        // The failed transaction attempt triggers a best-effort rollback.
+        when(() => mockClient.v1<void>(any())).thenAnswer((_) async {});
+
+        var callCount = 0;
+        when(
+          () => mockClient.v1<Stream<firestore_v1.RunQueryResponse>>(any()),
+        ).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) {
+            // First read starts the transaction successfully.
+            return Stream.fromIterable([
+              firestore_v1.RunQueryResponse(
+                transaction: Uint8List.fromList([1, 2, 3]),
+              ),
+            ]);
+          }
+          // Second read, already inside the now-active transaction, fails and
+          // must not be retried by the reader itself.
+          return Stream<firestore_v1.RunQueryResponse>.error(
+            _connectionClosedError,
+          );
+        });
+
+        final query = firestore.collection('numbers');
+
+        await expectLater(
+          firestore.runTransaction((tx) async {
+            await tx.getQuery(query);
+            return tx.getQuery(query);
+          }),
+          throwsA(isA<http.ClientException>()),
+        );
+
+        expect(callCount, 2);
+      });
+    },
+  );
+
   group('Transaction Query', () {
     late Firestore firestore;
 
@@ -313,5 +408,5 @@ void main() {
       expect(result['singleValue'], 1);
       expect(result['queryCount'], 2);
     });
-  });
+  }, tags: 'firebase-emulator');
 }


### PR DESCRIPTION
Fixes #291.

under high concurrency, `Query.get()`, `AggregateQuery.get()`, `Transaction.getQuery()`, and `Transaction.getAggregateQuery()` could throw `ClientException: Connection closed before full header was received` — a known `dart:io HttpClient` keep-alive race with no client-side fix except retrying. Added a shared `retryOnConnectionError` helper that retries with backoff when no partial results were received yet and the read isn't inside an active transaction.