### PR TITLE
feat(firestore): add maxConnectionsPerHost to Settings

### DIFF
--- a/packages/google_cloud_firestore/lib/src/firestore.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore.dart
@@ -116,6 +116,7 @@ class Settings {
     this.ignoreUndefinedProperties = false,
     this.useBigInt = false,
     this.environmentOverride,
+    this.maxConnectionsPerHost,
   });
 
   /// The project ID from the Google Developer's Console, e.g. 'grape-spaceship-123'.
@@ -186,6 +187,12 @@ class Settings {
   /// ```
   final Map<String, String>? environmentOverride;
 
+  /// The maximum number of concurrent connections allowed per host.
+  ///
+  /// If specified, this configures the underlying HTTP client's
+  /// `maxConnectionsPerHost` property.
+  final int? maxConnectionsPerHost;
+
   /// Creates a copy of this Settings with the given fields replaced.
   Settings copyWith({
     String? projectId,
@@ -196,6 +203,7 @@ class Settings {
     bool? ignoreUndefinedProperties,
     bool? useBigInt,
     Map<String, String>? environmentOverride,
+    int? maxConnectionsPerHost,
   }) {
     return Settings(
       projectId: projectId ?? this.projectId,
@@ -207,6 +215,8 @@ class Settings {
           ignoreUndefinedProperties ?? this.ignoreUndefinedProperties,
       useBigInt: useBigInt ?? this.useBigInt,
       environmentOverride: environmentOverride ?? this.environmentOverride,
+      maxConnectionsPerHost:
+          maxConnectionsPerHost ?? this.maxConnectionsPerHost,
     );
   }
 
@@ -221,7 +231,8 @@ class Settings {
           ssl == other.ssl &&
           credential == other.credential &&
           ignoreUndefinedProperties == other.ignoreUndefinedProperties &&
-          useBigInt == other.useBigInt;
+          useBigInt == other.useBigInt &&
+          maxConnectionsPerHost == other.maxConnectionsPerHost;
 
   @override
   int get hashCode => Object.hash(
@@ -232,6 +243,7 @@ class Settings {
     credential,
     ignoreUndefinedProperties,
     useBigInt,
+    maxConnectionsPerHost,
   );
 }
 

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:google_cloud/constants.dart' as google_cloud;
 import 'package:google_cloud/google_cloud.dart' as google_cloud;
 import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
 import 'package:googleapis_auth/auth_io.dart' as googleapis_auth;
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:meta/meta.dart';
 
 import '../google_cloud_firestore.dart';
@@ -156,9 +158,16 @@ class FirestoreHttpClient {
 
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
+    Client? baseClient;
+    final maxConnections = _settings.maxConnectionsPerHost;
+    if (maxConnections != null) {
+      final ioClient = HttpClient()..maxConnectionsPerHost = maxConnections;
+      baseClient = IOClient(ioClient);
+    }
+
     if (_isUsingEmulator) {
       // Emulator: Create unauthenticated client.
-      return EmulatorClient(Client());
+      return EmulatorClient(baseClient ?? Client());
     }
 
     // Production: Create authenticated client.
@@ -166,12 +175,13 @@ class FirestoreHttpClient {
     if (serviceAccountCreds != null) {
       return googleapis_auth.clientViaServiceAccount(serviceAccountCreds, [
         'https://www.googleapis.com/auth/cloud-platform',
-      ]);
+      ], baseClient: baseClient);
     }
 
     // Fall back to Application Default Credentials
     return googleapis_auth.clientViaApplicationDefaultCredentials(
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      baseClient: baseClient,
     );
   }
 


### PR DESCRIPTION
[WARNING: AI generated, as inspiration only, not meant to land]

Allows configuring the underlying HTTP client's maxConnectionsPerHost to improve performance of concurrent requests when using the REST API.

## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
