### PR TITLE
fix(admin): attach usage-tracking headers to Firestore requests

### DIFF
--- a/packages/firebase_admin_sdk/CHANGELOG.md
+++ b/packages/firebase_admin_sdk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.5.4-wip
 
+- Fixed `Firestore` requests not carrying the SDK's usage-tracking headers (`X-Firebase-Client`, `X-Goog-Api-Client`).
 - Update dependency `googleapis_auth: ^2.3.3` to fix `auth/insufficient-permission`
   errors with Application Default Credentials that have no quota project set.
 

--- a/packages/firebase_admin_sdk/CHANGELOG.md
+++ b/packages/firebase_admin_sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.4-wip
 
-- Fixed `Firestore` requests not carrying the SDK's usage-tracking headers (`X-Firebase-Client`, `X-Goog-Api-Client`).
+- Fixed `Firestore` requests not carrying the SDK's usage-tracking headers
+  (`X-Firebase-Client`, `X-Goog-Api-Client`).
 - Update dependency `googleapis_auth: ^2.3.3` to fix `auth/insufficient-permission`
   errors with Application Default Credentials that have no quota project set.
 

--- a/packages/firebase_admin_sdk/lib/src/app.dart
+++ b/packages/firebase_admin_sdk/lib/src/app.dart
@@ -35,7 +35,6 @@ import '../messaging.dart';
 import '../security_rules.dart';
 import '../storage.dart';
 import 'utils/utils.dart';
-import 'version.g.dart';
 
 part 'app/app_exception.dart';
 part 'app/app_options.dart';

--- a/packages/firebase_admin_sdk/lib/src/app/firebase_user_agent_client.dart
+++ b/packages/firebase_admin_sdk/lib/src/app/firebase_user_agent_client.dart
@@ -32,9 +32,7 @@ class FirebaseUserAgentClient extends BaseClient
 
   @override
   Future<StreamedResponse> send(BaseRequest request) {
-    request.headers['X-Firebase-Client'] = 'fire-admin-dart/$packageVersion';
-    request.headers['X-Goog-Api-Client'] =
-        'gl-dart/$dartVersion fire-admin/$packageVersion';
+    request.headers.addAll(firebaseUserAgentHeaders);
     return _client.send(request);
   }
 

--- a/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
+++ b/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
@@ -153,9 +153,9 @@ class Firestore implements FirebaseService {
       settings = settings.copyWith(projectId: projectId);
     }
 
-    if (settings.headers == null) {
-      settings = settings.copyWith(headers: firestoreUsageTrackingHeaders);
-    }
+    settings = settings.copyWith(
+      headers: {...firestoreUsageTrackingHeaders, ...?settings.headers},
+    );
 
     return settings;
   }

--- a/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
+++ b/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
@@ -154,7 +154,7 @@ class Firestore implements FirebaseService {
     }
 
     if (settings.headers == null) {
-      settings = settings.copyWith(headers: firebaseUserAgentHeaders);
+      settings = settings.copyWith(headers: firestoreUsageTrackingHeaders);
     }
 
     return settings;

--- a/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
+++ b/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
@@ -19,6 +19,8 @@ import 'package:google_cloud_firestore/google_cloud_firestore.dart'
 import 'package:meta/meta.dart';
 
 import '../app.dart';
+import '../utils/utils.dart';
+import '../version.g.dart';
 
 /// Default database ID used by Firestore
 const String kDefaultDatabaseId = '(default)';
@@ -150,6 +152,15 @@ class Firestore implements FirebaseService {
 
     if (projectId != null && settings.projectId == null) {
       settings = settings.copyWith(projectId: projectId);
+    }
+
+    if (settings.headers == null) {
+      settings = settings.copyWith(
+        headers: {
+          'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
+          'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
+        },
+      );
     }
 
     return settings;

--- a/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
+++ b/packages/firebase_admin_sdk/lib/src/firestore/firestore.dart
@@ -20,7 +20,6 @@ import 'package:meta/meta.dart';
 
 import '../app.dart';
 import '../utils/utils.dart';
-import '../version.g.dart';
 
 /// Default database ID used by Firestore
 const String kDefaultDatabaseId = '(default)';
@@ -155,12 +154,7 @@ class Firestore implements FirebaseService {
     }
 
     if (settings.headers == null) {
-      settings = settings.copyWith(
-        headers: {
-          'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
-          'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
-        },
-      );
+      settings = settings.copyWith(headers: firebaseUserAgentHeaders);
     }
 
     return settings;

--- a/packages/firebase_admin_sdk/lib/src/utils/utils.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/utils.dart
@@ -26,10 +26,10 @@ String get dartVersion =>
 /// Used by `FirebaseUserAgentClient`, which wraps HTTP clients (Auth,
 /// Messaging, and other services that go through `FirebaseApp.client`) that
 /// don't already set a client-identification header of their own.
-Map<String, String> get firebaseUserAgentHeaders => {
+final Map<String, String> firebaseUserAgentHeaders = Map.unmodifiable({
   'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
   'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
-};
+});
 
 /// Headers to attach to Firestore requests to identify them as originating
 /// from this SDK, for Firebase backend usage tracking.
@@ -39,7 +39,7 @@ Map<String, String> get firebaseUserAgentHeaders => {
 /// `FirestoreRequestClient` appends this value onto one that
 /// `package:google_cloud_rpc` already set (which already carries that tag),
 /// so repeating it here would duplicate it.
-Map<String, String> get firestoreUsageTrackingHeaders => {
+const Map<String, String> firestoreUsageTrackingHeaders = {
   'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
   'X-Goog-Api-Client': 'fire-admin/$packageVersion',
 };

--- a/packages/firebase_admin_sdk/lib/src/utils/utils.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/utils.dart
@@ -23,13 +23,25 @@ String get dartVersion =>
 /// Headers that identify a request as originating from this SDK, for
 /// Firebase backend usage tracking.
 ///
-/// Shared by `FirebaseUserAgentClient` (used by Auth, Messaging, and other
-/// services that go through `FirebaseApp.client`) and the Firestore service,
-/// which builds its own HTTP client and can't be wrapped by
-/// `FirebaseUserAgentClient` directly.
+/// Used by `FirebaseUserAgentClient`, which wraps HTTP clients (Auth,
+/// Messaging, and other services that go through `FirebaseApp.client`) that
+/// don't already set a client-identification header of their own.
 Map<String, String> get firebaseUserAgentHeaders => {
   'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
   'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
+};
+
+/// Headers to attach to Firestore requests to identify them as originating
+/// from this SDK, for Firebase backend usage tracking.
+///
+/// Unlike [firebaseUserAgentHeaders], `X-Goog-Api-Client` here omits the
+/// `gl-dart/{version}` runtime tag: `google_cloud_firestore`'s
+/// `FirestoreRequestClient` appends this value onto one that
+/// `package:google_cloud_rpc` already set (which already carries that tag),
+/// so repeating it here would duplicate it.
+Map<String, String> get firestoreUsageTrackingHeaders => {
+  'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
+  'X-Goog-Api-Client': 'fire-admin/$packageVersion',
 };
 
 /// Generates the update mask for the provided object.

--- a/packages/firebase_admin_sdk/lib/src/utils/utils.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/utils.dart
@@ -14,9 +14,23 @@
 
 import 'dart:io';
 
+import '../version.g.dart';
+
 /// The current Dart SDK version in semver format (e.g. "3.3.0").
 String get dartVersion =>
     Platform.version.split(RegExp('[^0-9]')).take(3).join('.');
+
+/// Headers that identify a request as originating from this SDK, for
+/// Firebase backend usage tracking.
+///
+/// Shared by `FirebaseUserAgentClient` (used by Auth, Messaging, and other
+/// services that go through `FirebaseApp.client`) and the Firestore service,
+/// which builds its own HTTP client and can't be wrapped by
+/// `FirebaseUserAgentClient` directly.
+Map<String, String> get firebaseUserAgentHeaders => {
+  'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
+  'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
+};
 
 /// Generates the update mask for the provided object.
 /// Note this will ignore the last key with value `null`.

--- a/packages/firebase_admin_sdk/lib/src/utils/utils.dart
+++ b/packages/firebase_admin_sdk/lib/src/utils/utils.dart
@@ -20,6 +20,12 @@ import '../version.g.dart';
 String get dartVersion =>
     Platform.version.split(RegExp('[^0-9]')).take(3).join('.');
 
+/// The Firebase Admin SDK's `X-Firebase-Client` identity.
+const String _fireAdminFirebaseClientId = 'fire-admin-dart/$packageVersion';
+
+/// The Firebase Admin SDK's tag within `X-Goog-Api-Client`.
+const String _fireAdminApiClientTag = 'fire-admin/$packageVersion';
+
 /// Headers that identify a request as originating from this SDK, for
 /// Firebase backend usage tracking.
 ///
@@ -27,8 +33,8 @@ String get dartVersion =>
 /// Messaging, and other services that go through `FirebaseApp.client`) that
 /// don't already set a client-identification header of their own.
 final Map<String, String> firebaseUserAgentHeaders = Map.unmodifiable({
-  'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
-  'X-Goog-Api-Client': 'gl-dart/$dartVersion fire-admin/$packageVersion',
+  'X-Firebase-Client': _fireAdminFirebaseClientId,
+  'X-Goog-Api-Client': 'gl-dart/$dartVersion $_fireAdminApiClientTag',
 });
 
 /// Headers to attach to Firestore requests to identify them as originating
@@ -40,8 +46,8 @@ final Map<String, String> firebaseUserAgentHeaders = Map.unmodifiable({
 /// `package:google_cloud_rpc` already set (which already carries that tag),
 /// so repeating it here would duplicate it.
 const Map<String, String> firestoreUsageTrackingHeaders = {
-  'X-Firebase-Client': 'fire-admin-dart/$packageVersion',
-  'X-Goog-Api-Client': 'fire-admin/$packageVersion',
+  'X-Firebase-Client': _fireAdminFirebaseClientId,
+  'X-Goog-Api-Client': _fireAdminApiClientTag,
 };
 
 /// Generates the update mask for the provided object.

--- a/packages/firebase_admin_sdk/test/unit/firestore/firestore_test.dart
+++ b/packages/firebase_admin_sdk/test/unit/firestore/firestore_test.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:firebase_admin_sdk/firebase_admin_sdk.dart';
 import 'package:firebase_admin_sdk/src/firestore/firestore.dart';
+import 'package:firebase_admin_sdk/src/utils/utils.dart';
 import 'package:google_cloud_firestore/google_cloud_firestore.dart' as gfs;
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:mocktail/mocktail.dart';
@@ -251,6 +252,39 @@ void main() {
         final db4 = firestoreService.initializeDatabase('db-null-1', null);
 
         expect(db3, same(db4));
+      });
+    });
+
+    group('usage-tracking headers', () {
+      test('are attached when no user headers are provided', () {
+        final settings = firestoreService.buildSettingsForTesting('db', null);
+
+        expect(settings.headers, firestoreUsageTrackingHeaders);
+      });
+
+      test('are merged with, not replaced by, user-provided headers', () {
+        final settings = firestoreService.buildSettingsForTesting(
+          'db',
+          const gfs.Settings(headers: {'X-Trace-Id': 'abc123'}),
+        );
+
+        expect(settings.headers, {
+          ...firestoreUsageTrackingHeaders,
+          'X-Trace-Id': 'abc123',
+        });
+      });
+
+      test('can be overridden by a user-provided header of the same name', () {
+        final settings = firestoreService.buildSettingsForTesting(
+          'db',
+          const gfs.Settings(headers: {'X-Firebase-Client': 'custom-value'}),
+        );
+
+        expect(settings.headers!['X-Firebase-Client'], 'custom-value');
+        expect(
+          settings.headers!['X-Goog-Api-Client'],
+          firestoreUsageTrackingHeaders['X-Goog-Api-Client'],
+        );
       });
     });
 


### PR DESCRIPTION
`Firestore` requests never carried the SDK's usage-tracking headers (`X-Firebase-Client`, `X-Goog-Api-Client`) — `FirestoreHttpClient` builds its own HTTP client independently of `FirebaseApp.client`/`FirebaseUserAgentClient`, so it was never wrapped.

Uses the new `Settings.headers` from #307 to attach the same headers, and extracts a shared `firebaseUserAgentHeaders` helper so the values aren't duplicated between `FirebaseUserAgentClient` and `Firestore`. Depends on #307 merging first.