### PR TITLE
test(example): verify example_server_app routes and enable in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,14 @@ jobs:
       - name: Run google_cloud_firestore tests with coverage
         run: ${{ github.workspace }}/scripts/firestore-coverage.sh
 
+      - name: Run firebase_admin_sdk example tests
+        working-directory: packages/firebase_admin_sdk/example
+        run: dart test
+
+      - name: Run firebase_admin_sdk example_server_app tests
+        working-directory: packages/firebase_admin_sdk/example_server_app
+        run: dart test
+
       - name: Process coverage and check threshold
         if: matrix.dart-version == 'stable'
         id: coverage

--- a/packages/firebase_admin_sdk/example_server_app/test/server_test.dart
+++ b/packages/firebase_admin_sdk/example_server_app/test/server_test.dart
@@ -32,6 +32,7 @@ void main() {
     // Wait for server to start and print to stdout that it is running.
     await p.stdout
         .transform(utf8.decoder)
+        .transform(const LineSplitter())
         .firstWhere((line) => line.contains('Server running on port'));
   });
 

--- a/packages/firebase_admin_sdk/example_server_app/test/server_test.dart
+++ b/packages/firebase_admin_sdk/example_server_app/test/server_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart';
@@ -24,26 +25,23 @@ void main() {
 
   setUp(() async {
     p = await Process.start(
-      'dart',
+      Platform.resolvedExecutable,
       ['run', 'bin/server.dart'],
       environment: {'PORT': port},
     );
-    // Wait for server to start and print to stdout.
-    await p.stdout.first;
+    // Wait for server to start and print to stdout that it is running.
+    await p.stdout
+        .transform(utf8.decoder)
+        .firstWhere((line) => line.contains('Server running on port'));
   });
 
   tearDown(() => p.kill());
 
-  test('Root', () async {
-    final response = await get(Uri.parse('$host/'));
+  test('Health', () async {
+    final response = await get(Uri.parse('$host/health'));
     expect(response.statusCode, 200);
-    expect(response.body, 'Hello, World!\n');
-  });
-
-  test('Echo', () async {
-    final response = await get(Uri.parse('$host/echo/hello'));
-    expect(response.statusCode, 200);
-    expect(response.body, 'hello\n');
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    expect(body['status'], 'healthy');
   });
 
   test('404', () async {


### PR DESCRIPTION
Why this change is needed:
Default shelf template test assertions rotted after server routes were
updated, as CI previously only executed sdk and firestore unit tests.

Summary of changes:
* Update test expectations from default boilerplate routes to /health.
* Use Platform.resolvedExecutable for child server subprocess spawns.
* Wait for server port bind before emitting test traffic.
* Add example and example_server_app test execution steps to build.yml.
