### PR TITLE
fix(storage): add idempotency guard to Storage.delete()

### DIFF
--- a/packages/firebase_admin_sdk/lib/src/storage/storage.dart
+++ b/packages/firebase_admin_sdk/lib/src/storage/storage.dart
@@ -112,8 +112,12 @@ class Storage implements FirebaseService {
     return '$endpoint/b/${bucket.name}/o/$encodedName?alt=media&token=$token';
   }
 
+  bool _isDeleted = false;
+
   @override
   Future<void> delete() async {
+    if (_isDeleted) return;
+    _isDeleted = true;
     _delegate.close();
   }
 }

--- a/packages/firebase_admin_sdk/test/unit/storage/storage_test.dart
+++ b/packages/firebase_admin_sdk/test/unit/storage/storage_test.dart
@@ -350,6 +350,20 @@ void main() {
         await testApp.close();
       });
 
+      test('should handle delete() called multiple times gracefully', () async {
+        final testApp = FirebaseApp.initializeApp(
+          name: 'multi-delete-test-${DateTime.now().millisecondsSinceEpoch}',
+          options: AppOptions(projectId: projectId, httpClient: mockClient),
+        );
+
+        final storage = Storage.internal(testApp);
+        expect(storage, isNotNull);
+
+        await storage.delete();
+        await storage.delete();
+        await testApp.close();
+      });
+
       test('should throw when accessing storage after app.close()', () async {
         final testApp = FirebaseApp.initializeApp(
           name: 'close-test-${DateTime.now().millisecondsSinceEpoch}',


### PR DESCRIPTION
Why this change is needed:
Calling storage.delete() followed by app.close() double-closed the delegate
HTTP client, triggering an unhandled async StateError during cleanup.

Summary of changes:
* Add an _isDeleted guard to Storage.delete() to prevent double closing.
* Add multi-delete lifecycle unit test matching Firestore test patterns.
